### PR TITLE
feat: add Conception Bay South source via Geotab Citizen Insights

### DIFF
--- a/src/where_the_plow/collector.py
+++ b/src/where_the_plow/collector.py
@@ -9,6 +9,7 @@ from where_the_plow.client import (
     parse_avl_response,
     parse_aatracking_response,
     parse_hitechmaps_response,
+    parse_geotab_response,
 )
 from where_the_plow.config import SOURCES
 from where_the_plow.db import Database
@@ -26,6 +27,8 @@ def process_poll(db: Database, response, source: str, parser: str) -> int:
         vehicles, positions = parse_aatracking_response(response, collected_at=now)
     elif parser == "hitechmaps":
         vehicles, positions = parse_hitechmaps_response(response, collected_at=now)
+    elif parser == "geotab":
+        vehicles, positions = parse_geotab_response(response, collected_at=now)
     else:
         raise ValueError(f"Unknown parser: {parser}")
 

--- a/src/where_the_plow/config.py
+++ b/src/where_the_plow/config.py
@@ -22,18 +22,24 @@ class Settings(BaseSettings):
         "https://gps5.aatracking.com/api/NewfoundlandPortal/GetPlows"
     )
     paradise_api_url: str = "https://hitechmaps.com/townparadise/db.php"
+    cbs_api_url: str = (
+        "https://citizeninsights.geotab.com/urlForFileFromBucket/Canada/"
+        "equipment-tracker-cbs-lp038h1u-b27A7-vehicle-locations.json"
+    )
 
     # Source enable/disable
     source_st_johns_enabled: bool = True
     source_mt_pearl_enabled: bool = True
     source_provincial_enabled: bool = True
     source_paradise_enabled: bool = True
+    source_cbs_enabled: bool = True
 
     # Source poll intervals (seconds)
     source_st_johns_poll_interval: int = 6
     source_mt_pearl_poll_interval: int = 30
     source_provincial_poll_interval: int = 30
     source_paradise_poll_interval: int = 10
+    source_cbs_poll_interval: int = 15
 
 
 settings = Settings()

--- a/src/where_the_plow/source_config.py
+++ b/src/where_the_plow/source_config.py
@@ -67,4 +67,15 @@ def build_sources(settings) -> dict[str, SourceConfig]:
             enabled=settings.source_paradise_enabled,
             min_coverage_zoom=10,
         ),
+        "cbs": SourceConfig(
+            name="cbs",
+            display_name="Conception Bay South",
+            api_url=settings.cbs_api_url,
+            poll_interval=settings.source_cbs_poll_interval,
+            center=(-52.98, 47.51),
+            zoom=12,
+            parser="geotab",
+            enabled=settings.source_cbs_enabled,
+            min_coverage_zoom=10,
+        ),
     }

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,9 +9,11 @@ def test_default_settings():
     assert s.source_mt_pearl_poll_interval == 30
     assert s.source_provincial_poll_interval == 30
     assert s.source_paradise_poll_interval == 10
+    assert s.source_cbs_poll_interval == 15
     assert s.log_level == "INFO"
     assert "MapServer" in s.avl_api_url
     assert "hitechmaps.com" in s.paradise_api_url
+    assert "citizeninsights.geotab.com" in s.cbs_api_url
 
 
 def test_settings_from_env(monkeypatch):
@@ -49,6 +51,7 @@ def test_sources_registry_has_required_sources():
     assert "mt_pearl" in SOURCES
     assert "provincial" in SOURCES
     assert "paradise" in SOURCES
+    assert "cbs" in SOURCES
 
 
 def test_source_config_has_required_fields():
@@ -59,7 +62,7 @@ def test_source_config_has_required_fields():
         assert src.poll_interval > 0
         assert len(src.center) == 2
         assert src.zoom > 0
-        assert src.parser in ("avl", "aatracking", "hitechmaps")
+        assert src.parser in ("avl", "aatracking", "hitechmaps", "geotab")
         assert src.min_coverage_zoom >= 0
 
 
@@ -83,6 +86,7 @@ def test_source_min_coverage_zoom():
     assert SOURCES["mt_pearl"].min_coverage_zoom == 10
     assert SOURCES["provincial"].min_coverage_zoom == 0
     assert SOURCES["paradise"].min_coverage_zoom == 10
+    assert SOURCES["cbs"].min_coverage_zoom == 10
 
 
 def test_build_sources_respects_disabled(monkeypatch):


### PR DESCRIPTION
## Summary
- Adds Conception Bay South as a fifth data source using Geotab's Citizen Insights platform
- Two-step fetch: request a signed GCS URL from `citizeninsights.geotab.com/urlForFileFromBucket/...`, then fetch vehicle data from the signed URL (30-minute expiry, re-requested each poll)
- Data is minimal: just `{vehicleId: [lng, lat]}` with no timestamps, speed, bearing, or names. Timestamps use `collected_at`, vehicle type assumed `SA PLOW TRUCK`
- Full reverse-engineering documented in `docs/research/cbs-geotab.md` including the config endpoint, service categories, file naming convention, and brittleness analysis

## How the Geotab API Works
1. `GET /config/equipment-tracker-cbs` returns deployment config with service category/group IDs
2. `GET /urlForFileFromBucket/Canada/{categoryId}-{groupId}-vehicle-locations.json` returns `{"url": "<signed GCS URL>"}`
3. Fetch the signed URL to get `{"b21": [-52.93, 47.51], ...}`

Only the snow plow category (`lp038h1u`/`b27A7`) is implemented. Waste and recycling categories exist but are not wired up.

## Test Plan
- 103/103 tests pass (3 new parser tests, 1 collector integration test, 1 two-step fetch test, config test updates)
- Verified against live API (3 vehicles observed, Feb 2026)

Closes #16