### PR TITLE
feat: region video export & shareable replay links (#29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,14 +56,14 @@ All geo endpoints return GeoJSON. Full OpenAPI docs at [`/docs`](https://plow.ja
 | `GET /vehicles` | Latest position for every vehicle (with mini-trails) |
 | `GET /vehicles/nearby?lat=&lng=&radius=` | Vehicles within radius (meters) |
 | `GET /vehicles/{id}/history?since=&until=` | Position history for one vehicle |
-| `GET /coverage?since=&until=` | Per-vehicle LineString trails with timestamps |
+| `GET /coverage?since=&until=&bbox=` | Per-vehicle LineString trails with timestamps |
 | `GET /search?q=` | Geocode an address via Nominatim (cached proxy) |
 | `GET /stats` | Collection statistics |
 | `GET /health` | Health check |
 | `POST /track` | Record anonymous viewport focus event |
 | `POST /signup` | Email signup for notifications |
 
-Vehicle and coverage endpoints support a `?source=` query parameter to filter by data source. All GET list endpoints support cursor-based pagination via `limit` and `after` query parameters. Write endpoints (`/track`, `/signup`) are rate-limited per IP.
+Vehicle and coverage endpoints support a `?source=` query parameter to filter by data source. The `/coverage` endpoint also accepts an optional `bbox=west,south,east,north` parameter to restrict results to a bounding box (e.g. `bbox=-52.8,47.5,-52.7,47.6`). All GET list endpoints support cursor-based pagination via `limit` and `after` query parameters. Write endpoints (`/track`, `/signup`) are rate-limited per IP.
 
 ## Database schema
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ All geo endpoints return GeoJSON. Full OpenAPI docs at [`/docs`](https://plow.ja
 | `GET /vehicles/nearby?lat=&lng=&radius=` | Vehicles within radius (meters) |
 | `GET /vehicles/{id}/history?since=&until=` | Position history for one vehicle |
 | `GET /coverage?since=&until=&bbox=` | Per-vehicle LineString trails with timestamps |
+| `GET /coverage/segments?since=&until=&bbox=&gap_threshold=` | Activity/gap time segments for a region |
 | `GET /search?q=` | Geocode an address via Nominatim (cached proxy) |
 | `GET /stats` | Collection statistics |
 | `GET /health` | Health check |

--- a/docs/plans/2026-02-25-region-video-export-design.md
+++ b/docs/plans/2026-02-25-region-video-export-design.md
@@ -1,0 +1,178 @@
+# Region Video Export & Shareable Replay
+
+**GitHub Issue:** #29 — Select a region, save a video of a "playback" of when plows visited that area, over a multi-day date range.
+
+**Goal:** Let users draw a polygon on the map, select a multi-day date range, and either (a) export an MP4 video of the plow playback within that region, or (b) copy a shareable link that replays the same view in-browser.
+
+---
+
+## User Flow
+
+1. **Enter export mode** — From coverage mode, click an "Export Region" button.
+2. **Draw a region** — Mapbox Draw activates with polygon, rectangle, and trash tools. User draws a shape on the map.
+3. **Select date range** — Reuse the existing date picker and time range controls, extended for multi-day ranges.
+4. **Preview** — App fetches `/coverage` with spatial filter, loads data, user can preview playback with the existing slider/play system. Camera auto-fits to the drawn region but user can pan/zoom to adjust.
+5. **Export MP4** — Mediabunny captures the MapLibre canvas frame-by-frame during a stepped (non-real-time) playback, compositing a timestamp + branding overlay. Downloads an MP4.
+6. **Share link** — "Copy Link" button encodes region, date range, speed, and camera into URL params. Opening that link loads the app in replay mode and auto-plays.
+
+---
+
+## Technology Choices
+
+### Region Drawing: `@mapbox/mapbox-gl-draw`
+
+- Official MapLibre-compatible plugin (documented in MapLibre examples).
+- Provides polygon + rectangle + trash tools.
+- ~150kB from CDN, no build step needed.
+- `draw.create` / `draw.update` events provide GeoJSON Feature with coordinates.
+
+### Video Encoding: Mediabunny
+
+- Pure TypeScript, zero dependencies, ~17kB for MP4 writing (vs ~25MB for FFmpeg WASM).
+- `CanvasSource` API captures a canvas element directly into H.264/MP4.
+- Hardware-accelerated encoding via WebCodecs API.
+- **Browser support:** Chrome, Edge, Safari 16.4+. No Firefox (WebCodecs not supported). Firefox users see a "video export not supported in this browser" message but can still use the shareable link for in-browser replay.
+
+### Spatial Filtering: DuckDB Spatial Extension
+
+- Already in use (`geom` column, `ST_Point`, spatial index on `positions`).
+- Add `ST_Intersects` / `ST_Within` filtering to the existing `/coverage` query.
+
+---
+
+## Backend Changes
+
+### Extend `/coverage` with spatial filtering
+
+Add two optional query parameters:
+
+- `bbox=west,south,east,north` — Bounding box filter (standard GeoJSON bbox order). Uses `ST_Intersects(geom, ST_MakeEnvelope(west, south, east, north))`.
+- `polygon=[[lng,lat],[lng,lat],...]` — URL-encoded GeoJSON coordinate ring. Uses `ST_Within(geom, ST_GeomFromGeoJSON(...))`. For shareable links reconstructing polygon-filtered views.
+
+No new endpoints needed. The existing `/coverage` response format (per-vehicle LineString trails with timestamps) contains everything the frontend needs.
+
+### Cache key extension
+
+The file-based cache in `cache.py` currently keys on `(since, until, source)`. Extend the cache key to include a hash of the bbox/polygon parameter so spatially filtered queries get cached too.
+
+---
+
+## Frontend Architecture
+
+### Recording Pipeline
+
+MapLibre renders to a WebGL canvas. During recording, a controlled (non-real-time) playback loop:
+
+1. Advances the coverage time to the next frame's timestamp.
+2. Waits for deck.gl TripsLayer to render the updated state.
+3. Composites the map canvas + overlay (timestamp + branding) onto an offscreen canvas.
+4. Feeds the composited canvas to Mediabunny's `CanvasSource`.
+
+**Stepped playback, not real-time:** During recording we do NOT use `requestAnimationFrame` at wall-clock speed. We step through time at the target framerate (30fps), render, capture, advance. This means:
+
+- A 5-day range compressed to 60 seconds = each frame represents ~2.4 hours.
+- Recording a 60-second video takes 30–90 seconds depending on rendering speed.
+- User sees a progress bar ("Encoding: 45%...").
+
+**Mediabunny setup (pseudocode):**
+
+```js
+const compositeCanvas = document.createElement('canvas');
+const ctx = compositeCanvas.getContext('2d');
+
+const videoSource = new CanvasSource(compositeCanvas, {
+    codec: 'avc',        // H.264 for widest playback compatibility
+    bitrate: 4_000_000,  // 4 Mbps, good for map content
+});
+
+const output = new Output({
+    format: new Mp4OutputFormat(),
+    target: new BufferTarget(),
+});
+output.addVideoTrack(videoSource, { frameRate: 30 });
+await output.start();
+
+for (let i = 0; i < totalFrames; i++) {
+    const t = startTime + (i / totalFrames) * (endTime - startTime);
+    updatePlaybackTime(t);          // advance TripsLayer currentTime
+    await waitForRender();           // wait for deck.gl to paint
+    ctx.drawImage(mapCanvas, 0, 0);  // copy map
+    drawOverlay(ctx, t);             // timestamp + branding
+    videoSource.add(i / 30, 1 / 30); // feed to encoder
+    updateProgress(i / totalFrames);
+}
+
+await output.finalize();
+downloadBlob(output.target.buffer, 'plow-coverage.mp4');
+```
+
+**Overlay:** `ctx.fillText()` on the compositing canvas. White text with dark shadow. Bottom-left: progressing timestamp. Bottom-right: `plow.jackharrhy.dev`.
+
+**Resolution:** Match map canvas resolution, or offer 720p/1080p picker (resize map container temporarily during recording).
+
+### Shareable Link
+
+**URL structure:**
+
+```
+https://plow.jackharrhy.dev/?mode=replay&since=2026-02-20&until=2026-02-25&speed=10&center=47.56,-52.71&zoom=13&polygon=[[-52.8,47.5],[-52.7,47.5],[-52.7,47.6],[-52.8,47.6]]
+```
+
+Parameters:
+- `mode=replay` — triggers replay mode on page load
+- `since` / `until` — date range
+- `speed` — animation duration in seconds
+- `center` / `zoom` — camera position
+- `polygon` — drawn region coordinates (URL-encoded)
+
+**On load:**
+1. Skip welcome modal.
+2. Fetch `/coverage` with spatial filter params.
+3. Set map camera to specified center/zoom.
+4. Draw polygon outline on map for context.
+5. Auto-start playback after data loads.
+6. Minimal UI: map + play/pause + time label.
+
+No server state. Links work as long as data exists in the database.
+
+### UI Integration
+
+**Entry point:** Sub-feature of coverage mode. "Export Region" button appears when in coverage mode.
+
+**Export panel contents:**
+- Mapbox Draw controls (polygon, rectangle, trash)
+- Date range pickers
+- Speed selector
+- "Preview" button (uses existing playback system)
+- "Export MP4" button (with WebCodecs support check)
+- "Copy Share Link" button
+
+**During recording:** Progress bar + "Cancel" button. Map locked, UI controls disabled.
+
+**After recording:** Download prompt + share link option.
+
+**Mobile:** Desktop-only or warning — video encoding is resource-intensive and polygon drawing on mobile is poor UX.
+
+---
+
+## Component Summary
+
+| Component | Technology | Status |
+|---|---|---|
+| Region drawing | `@mapbox/mapbox-gl-draw` via CDN | New |
+| Video encoding | Mediabunny (`CanvasSource` + `Mp4OutputFormat`) via CDN | New |
+| Spatial data filtering | DuckDB `ST_Intersects` / `ST_Within` | Modified `/coverage` |
+| Coverage cache | Extend cache key with bbox/polygon hash | Modified `cache.py` |
+| Playback engine | Existing slider + TripsLayer | Modified (stepped mode for recording) |
+| Shareable links | URL params, parsed on page load | New |
+| Export UI panel | Vanilla JS/HTML/CSS | New |
+
+---
+
+## Open Questions / Future Work
+
+- **Video duration control:** Should the user specify total video duration, or is speed (relative to real time) enough?
+- **Audio:** Could add ambient/sound effects to the video in a future iteration.
+- **Polygon simplification:** For complex polygons, simplify before encoding into URL to keep link length reasonable.
+- **Data pruning:** What happens when old data is pruned? Shareable links for pruned ranges should show a clear "no data" message.
+- **Rate limiting:** Should video export trigger any server-side concern? The `/coverage` call is cached, so probably not — but worth monitoring.

--- a/docs/plans/2026-02-25-region-video-export-impl.md
+++ b/docs/plans/2026-02-25-region-video-export-impl.md
@@ -1,0 +1,1135 @@
+# Region Video Export Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Let users draw a polygon on the map, select a multi-day date range, and export an MP4 video of the plow playback within that region, or copy a shareable link that replays the same view in-browser.
+
+**Architecture:** Extends the existing `/coverage` endpoint with spatial filtering (bbox param, DuckDB `ST_Intersects`). Frontend adds Mapbox Draw for polygon selection, Mediabunny for MP4 encoding from the MapLibre canvas, and URL-param-based replay mode. All new frontend code lives in the existing `app.js` / `index.html` / `style.css` files. No build step.
+
+**Tech Stack:** Python/FastAPI, DuckDB spatial, MapLibre GL JS v5, `@mapbox/mapbox-gl-draw` via CDN, Mediabunny via CDN, deck.gl TripsLayer (existing), vanilla JS.
+
+---
+
+### Task 1: Add `bbox` parameter to `/coverage` backend endpoint
+
+Add optional spatial filtering to the existing `/coverage` route and `get_coverage_trails()` DB method. This is the foundation for all region-based queries.
+
+**Files:**
+- Modify: `src/where_the_plow/db.py:276-354` (`get_coverage_trails`)
+- Modify: `src/where_the_plow/routes.py:351-400` (`get_coverage`)
+- Test: `tests/test_db.py`
+- Test: `tests/test_routes.py`
+
+**Step 1: Write failing DB test for bbox filtering**
+
+Add to `tests/test_db.py`:
+
+```python
+def test_get_coverage_trails_bbox_filter():
+    """Bbox filter should only return positions within the bounding box."""
+    db, path = make_db()
+    now = datetime.now(timezone.utc)
+    ts1 = datetime(2026, 2, 19, 12, 0, 0, tzinfo=timezone.utc)
+    ts2 = datetime(2026, 2, 19, 12, 0, 30, tzinfo=timezone.utc)
+    ts3 = datetime(2026, 2, 19, 12, 1, 0, tzinfo=timezone.utc)
+
+    db.upsert_vehicles(
+        [
+            {"vehicle_id": "v1", "description": "Plow 1", "vehicle_type": "SA PLOW TRUCK"},
+            {"vehicle_id": "v2", "description": "Plow 2", "vehicle_type": "LOADER"},
+        ],
+        now,
+    )
+    # v1 in downtown area (-52.73, 47.56) to (-52.75, 47.58)
+    # v2 far away at (-53.00, 47.30)
+    db.insert_positions(
+        [
+            {"vehicle_id": "v1", "timestamp": ts1, "longitude": -52.73, "latitude": 47.56, "bearing": 0, "speed": 10.0, "is_driving": "maybe"},
+            {"vehicle_id": "v1", "timestamp": ts2, "longitude": -52.74, "latitude": 47.57, "bearing": 90, "speed": 15.0, "is_driving": "maybe"},
+            {"vehicle_id": "v1", "timestamp": ts3, "longitude": -52.75, "latitude": 47.58, "bearing": 180, "speed": 20.0, "is_driving": "maybe"},
+            {"vehicle_id": "v2", "timestamp": ts1, "longitude": -53.00, "latitude": 47.30, "bearing": 0, "speed": 5.0, "is_driving": "maybe"},
+            {"vehicle_id": "v2", "timestamp": ts2, "longitude": -53.01, "latitude": 47.31, "bearing": 0, "speed": 5.0, "is_driving": "maybe"},
+            {"vehicle_id": "v2", "timestamp": ts3, "longitude": -53.02, "latitude": 47.32, "bearing": 0, "speed": 5.0, "is_driving": "maybe"},
+        ],
+        now,
+    )
+
+    # Bbox around downtown — should include v1, exclude v2
+    trails = db.get_coverage_trails(
+        since=ts1, until=ts3, bbox=(-52.80, 47.50, -52.70, 47.60)
+    )
+    assert len(trails) == 1
+    assert trails[0]["vehicle_id"] == "v1"
+
+    # Bbox around v2's area — should include v2, exclude v1
+    trails = db.get_coverage_trails(
+        since=ts1, until=ts3, bbox=(-53.10, 47.25, -52.95, 47.35)
+    )
+    assert len(trails) == 1
+    assert trails[0]["vehicle_id"] == "v2"
+
+    # Bbox that includes neither
+    trails = db.get_coverage_trails(
+        since=ts1, until=ts3, bbox=(-50.00, 48.00, -49.00, 49.00)
+    )
+    assert len(trails) == 0
+
+    # No bbox — returns both vehicles
+    trails = db.get_coverage_trails(since=ts1, until=ts3)
+    assert len(trails) == 2
+
+    db.close()
+    os.unlink(path)
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_db.py::test_get_coverage_trails_bbox_filter -v`
+Expected: FAIL with `TypeError: get_coverage_trails() got an unexpected keyword argument 'bbox'`
+
+**Step 3: Implement bbox filtering in `get_coverage_trails()`**
+
+In `src/where_the_plow/db.py`, modify the `get_coverage_trails` method signature and query. Add `bbox` parameter as `tuple[float, float, float, float] | None = None` (west, south, east, north).
+
+Add after the source filter block (line 292):
+
+```python
+bbox_filter = ""
+if bbox is not None:
+    west, south, east, north = bbox
+    bbox_filter = f"AND ST_Intersects(p.geom, ST_MakeEnvelope(${len(params)+1}, ${len(params)+2}, ${len(params)+3}, ${len(params)+4}))"
+    params.extend([west, south, east, north])
+```
+
+Insert `{bbox_filter}` into the query's WHERE clause after `{source_filter}` (line 310).
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_db.py::test_get_coverage_trails_bbox_filter -v`
+Expected: PASS
+
+**Step 5: Write failing route test for bbox query param**
+
+Add to `tests/test_routes.py`:
+
+```python
+def test_get_coverage_with_bbox_filter(test_client):
+    # v1 positions are around (-52.73 to -52.75, 47.56 to 47.58)
+    # v2 position is at (-52.80, 47.50) — only 1 position so no trail
+    # Bbox around v1 — should return v1's trail
+    resp = test_client.get(
+        "/coverage?since=2026-02-19T00:00:00Z&until=2026-02-20T00:00:00Z"
+        "&bbox=-52.80,47.50,-52.70,47.60"
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["type"] == "FeatureCollection"
+    assert len(data["features"]) == 1
+    assert data["features"][0]["properties"]["vehicle_id"] == "v1"
+
+    # Bbox far away — should return empty
+    resp = test_client.get(
+        "/coverage?since=2026-02-19T00:00:00Z&until=2026-02-20T00:00:00Z"
+        "&bbox=-50.00,48.00,-49.00,49.00"
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["features"]) == 0
+```
+
+**Step 6: Implement bbox query param in route**
+
+In `src/where_the_plow/routes.py`, add to the `get_coverage` function signature:
+
+```python
+bbox: str | None = Query(
+    None,
+    description="Bounding box filter: west,south,east,north (e.g. '-52.8,47.5,-52.7,47.6')",
+),
+```
+
+Parse it into a tuple before passing to `db.get_coverage_trails()`:
+
+```python
+bbox_tuple = None
+if bbox is not None:
+    try:
+        parts = [float(x) for x in bbox.split(",")]
+        if len(parts) != 4:
+            raise ValueError
+        bbox_tuple = tuple(parts)
+    except ValueError:
+        from fastapi.responses import JSONResponse
+        return JSONResponse(
+            status_code=422,
+            content={"detail": "bbox must be 4 comma-separated floats: west,south,east,north"},
+        )
+```
+
+Pass `bbox=bbox_tuple` to `db.get_coverage_trails(...)`.
+
+Update cache key logic: include bbox in both in-memory and file cache keys. For in-memory cache, change the key to `(since_iso, until_iso, source, bbox)`. For the file cache, modify `cache._cache_key` to accept an optional `bbox_str` parameter and include it in the hash.
+
+**Step 7: Run all tests**
+
+Run: `uv run pytest tests/test_routes.py tests/test_db.py -v`
+Expected: All PASS
+
+**Step 8: Commit**
+
+```bash
+git add src/where_the_plow/db.py src/where_the_plow/routes.py src/where_the_plow/cache.py tests/test_db.py tests/test_routes.py
+git commit -m "feat: add bbox spatial filter to /coverage endpoint (#29)"
+```
+
+---
+
+### Task 2: Add Mapbox Draw CDN and export UI panel HTML/CSS
+
+Add the Mapbox Draw library, create the export UI panel in the HTML, and style it. No JS logic yet — just the static structure.
+
+**Files:**
+- Modify: `src/where_the_plow/static/index.html:72-74` (CDN scripts), `113-161` (coverage panel)
+- Modify: `src/where_the_plow/static/style.css`
+
+**Step 1: Add Mapbox Draw CDN links**
+
+In `index.html`, add after the noUiSlider CSS link (line 69-70):
+
+```html
+<link rel="stylesheet" href="https://unpkg.com/@mapbox/mapbox-gl-draw@1/dist/mapbox-gl-draw.css" />
+```
+
+Add after the noUiSlider JS script (line 74):
+
+```html
+<script src="https://unpkg.com/@mapbox/mapbox-gl-draw@1/dist/mapbox-gl-draw.js"></script>
+```
+
+**Step 2: Add Mediabunny CDN script**
+
+Add after the Mapbox Draw script:
+
+```html
+<script type="module" id="mediabunny-loader">
+    import { Output, Mp4OutputFormat, BufferTarget, CanvasSource } from 'https://esm.sh/mediabunny@0';
+    window.Mediabunny = { Output, Mp4OutputFormat, BufferTarget, CanvasSource };
+    window.dispatchEvent(new Event('mediabunny-ready'));
+</script>
+```
+
+Note: Mediabunny is ESM-only, so we use an inline module script that imports from esm.sh and exposes the needed classes on `window.Mediabunny`. The `mediabunny-ready` event lets `app.js` (which is a classic script) know when it's available.
+
+**Step 3: Add export panel HTML**
+
+In `index.html`, add inside the `#coverage-panel` div, after the `#coverage-loading` div (line 160), before the closing `</div>` of `#coverage-panel`:
+
+```html
+<div id="export-panel" style="display: none">
+    <div class="coverage-hint export-section-title">
+        Export Region Video
+    </div>
+    <div id="export-draw-controls" class="export-row">
+        <button id="btn-draw-polygon" title="Draw polygon">Polygon</button>
+        <button id="btn-draw-rectangle" title="Draw rectangle">Rectangle</button>
+        <button id="btn-draw-clear" title="Clear drawing" disabled>Clear</button>
+    </div>
+    <div id="export-date-range" class="export-row">
+        <label>From</label>
+        <input type="date" id="export-date-start" />
+        <label>To</label>
+        <input type="date" id="export-date-end" />
+    </div>
+    <div id="export-speed-row" class="export-row">
+        <label>Video duration</label>
+        <select id="export-speed">
+            <option value="15">15s</option>
+            <option value="30" selected>30s</option>
+            <option value="60">1m</option>
+        </select>
+    </div>
+    <div id="export-actions" class="export-row">
+        <button id="btn-export-preview" disabled>Preview</button>
+        <button id="btn-export-record" disabled>Export MP4</button>
+        <button id="btn-export-link" disabled>Copy Link</button>
+    </div>
+    <div id="export-progress" style="display: none">
+        <div id="export-progress-bar">
+            <div id="export-progress-fill"></div>
+        </div>
+        <span id="export-progress-text">Encoding...</span>
+        <button id="btn-export-cancel">Cancel</button>
+    </div>
+    <div id="export-unsupported" style="display: none">
+        Video export requires a Chromium-based browser (Chrome, Edge) or Safari 16.4+.
+    </div>
+</div>
+```
+
+**Step 4: Add entry button for export mode**
+
+In `index.html`, add a button after the `#coverage-view-toggle` div (line 133):
+
+```html
+<button id="btn-export-mode" class="export-toggle-btn" style="display: none">Export Region</button>
+```
+
+This button is hidden by default, shown when in coverage mode.
+
+**Step 5: Style the export panel**
+
+Add to `style.css` after the existing coverage panel styles (around line 369):
+
+```css
+/* ── Export panel ───────────────────────────────── */
+
+.export-toggle-btn {
+    width: 100%;
+    padding: 6px 10px;
+    margin: 6px 0;
+    background: var(--color-accent);
+    color: #fff;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.8rem;
+}
+.export-toggle-btn:hover {
+    opacity: 0.9;
+}
+
+#export-panel {
+    margin-top: 8px;
+    padding-top: 8px;
+    border-top: 1px solid var(--border-subtle);
+}
+
+.export-section-title {
+    font-weight: 600;
+    margin-bottom: 6px;
+}
+
+.export-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-bottom: 6px;
+    flex-wrap: wrap;
+}
+
+.export-row label {
+    font-size: 0.75rem;
+    color: var(--color-text-secondary);
+    white-space: nowrap;
+}
+
+.export-row input[type="date"] {
+    flex: 1;
+    min-width: 0;
+    background: var(--color-input-bg);
+    color: var(--color-text);
+    border: 1px solid var(--border-subtle);
+    border-radius: 3px;
+    padding: 3px 4px;
+    font-size: 0.75rem;
+}
+
+.export-row select {
+    flex: 1;
+    background: var(--color-input-bg);
+    color: var(--color-text);
+    border: 1px solid var(--border-subtle);
+    border-radius: 3px;
+    padding: 3px 4px;
+    font-size: 0.75rem;
+}
+
+#export-draw-controls button {
+    flex: 1;
+    padding: 4px 8px;
+    background: var(--color-input-bg);
+    color: var(--color-text);
+    border: 1px solid var(--border-subtle);
+    border-radius: 3px;
+    cursor: pointer;
+    font-size: 0.75rem;
+}
+#export-draw-controls button:hover:not(:disabled) {
+    background: var(--color-hover-bg);
+}
+#export-draw-controls button:disabled {
+    opacity: 0.4;
+    cursor: default;
+}
+
+#export-actions button {
+    flex: 1;
+    padding: 5px 8px;
+    border: 1px solid var(--border-subtle);
+    border-radius: 3px;
+    cursor: pointer;
+    font-size: 0.75rem;
+    background: var(--color-input-bg);
+    color: var(--color-text);
+}
+#export-actions button:disabled {
+    opacity: 0.4;
+    cursor: default;
+}
+#btn-export-record {
+    background: var(--color-accent);
+    color: #fff;
+    border-color: var(--color-accent);
+}
+#btn-export-record:disabled {
+    background: var(--color-input-bg);
+    color: var(--color-text);
+    border-color: var(--border-subtle);
+}
+
+#export-progress {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: 6px;
+}
+#export-progress-bar {
+    flex: 1;
+    height: 6px;
+    background: var(--color-input-bg);
+    border-radius: 3px;
+    overflow: hidden;
+}
+#export-progress-fill {
+    height: 100%;
+    width: 0%;
+    background: var(--color-accent);
+    transition: width 0.2s;
+}
+#export-progress-text {
+    font-size: 0.7rem;
+    color: var(--color-text-secondary);
+    white-space: nowrap;
+}
+#btn-export-cancel {
+    padding: 2px 8px;
+    background: transparent;
+    color: var(--color-text-muted);
+    border: 1px solid var(--border-subtle);
+    border-radius: 3px;
+    cursor: pointer;
+    font-size: 0.7rem;
+}
+
+#export-unsupported {
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+    padding: 4px 0;
+}
+```
+
+**Step 6: Commit**
+
+```bash
+git add src/where_the_plow/static/index.html src/where_the_plow/static/style.css
+git commit -m "feat: add export panel HTML/CSS and Mapbox Draw + Mediabunny CDN (#29)"
+```
+
+---
+
+### Task 3: Wire up Mapbox Draw for region selection
+
+Initialize Mapbox Draw, wire the draw/clear buttons, and track the drawn polygon. When a polygon is drawn + dates are selected, enable the Preview/Export/Link buttons.
+
+**Files:**
+- Modify: `src/where_the_plow/static/app.js`
+
+**Step 1: Add Draw initialization in PlowMap**
+
+In the `PlowMap` class (around line 350 in app.js), add a method to initialize and manage Mapbox Draw:
+
+```js
+initDraw() {
+    this.draw = new MapboxDraw({
+        displayControlsDefault: false,
+        controls: {},  // We use custom buttons, not built-in controls
+        defaultMode: 'simple_select',
+    });
+    this.map.addControl(this.draw, 'top-left');
+    // Hide the default draw controls (we have our own buttons)
+    const drawControls = this.map.getContainer().querySelector('.mapboxgl-ctrl-group.mapboxgl-ctrl-top-left');
+    if (drawControls) drawControls.style.display = 'none';
+}
+
+getDrawnPolygon() {
+    if (!this.draw) return null;
+    const data = this.draw.getAll();
+    if (!data || data.features.length === 0) return null;
+    return data.features[0];  // Only allow one polygon at a time
+}
+
+clearDraw() {
+    if (this.draw) this.draw.deleteAll();
+}
+
+getDrawnBbox() {
+    const feature = this.getDrawnPolygon();
+    if (!feature) return null;
+    const coords = feature.geometry.coordinates[0];
+    let west = Infinity, south = Infinity, east = -Infinity, north = -Infinity;
+    for (const [lng, lat] of coords) {
+        if (lng < west) west = lng;
+        if (lng > east) east = lng;
+        if (lat < south) south = lat;
+        if (lat > north) north = lat;
+    }
+    return [west, south, east, north];
+}
+```
+
+**Step 2: Add export state and methods to PlowApp**
+
+Add to the `PlowApp` constructor state:
+
+```js
+// Export
+this.exportMode = false;
+this.exportPolygon = null;
+```
+
+Add export mode methods to `PlowApp`:
+
+```js
+/* ── Export mode ────────────────────────────────── */
+
+enterExportMode() {
+    this.exportMode = true;
+    this.map.initDraw();
+    document.getElementById('export-panel').style.display = 'block';
+    document.getElementById('btn-export-mode').textContent = 'Exit Export';
+
+    // Set date picker bounds
+    const startInput = document.getElementById('export-date-start');
+    const endInput = document.getElementById('export-date-end');
+    if (coverageDateInput.min) startInput.min = coverageDateInput.min;
+    if (coverageDateInput.max) endInput.max = coverageDateInput.max;
+    startInput.max = coverageDateInput.max;
+    endInput.min = startInput.min;
+
+    // Default: last 3 days
+    const now = new Date();
+    const threeDaysAgo = new Date(now.getTime() - 3 * 24 * 60 * 60 * 1000);
+    endInput.value = now.toISOString().slice(0, 10);
+    startInput.value = threeDaysAgo.toISOString().slice(0, 10);
+
+    // Check WebCodecs support
+    if (typeof VideoEncoder === 'undefined') {
+        document.getElementById('export-unsupported').style.display = 'block';
+        document.getElementById('btn-export-record').disabled = true;
+    }
+
+    this.updateExportButtons();
+}
+
+exitExportMode() {
+    this.exportMode = false;
+    this.map.clearDraw();
+    // Remove draw control
+    if (this.map.draw) {
+        this.map.map.removeControl(this.map.draw);
+        this.map.draw = null;
+    }
+    document.getElementById('export-panel').style.display = 'none';
+    document.getElementById('btn-export-mode').textContent = 'Export Region';
+    document.getElementById('export-unsupported').style.display = 'none';
+    this.exportPolygon = null;
+}
+
+updateExportButtons() {
+    const hasPolygon = this.map.getDrawnPolygon() !== null;
+    const startDate = document.getElementById('export-date-start').value;
+    const endDate = document.getElementById('export-date-end').value;
+    const hasDates = startDate && endDate && startDate <= endDate;
+    const ready = hasPolygon && hasDates;
+
+    document.getElementById('btn-draw-clear').disabled = !hasPolygon;
+    document.getElementById('btn-export-preview').disabled = !ready;
+    document.getElementById('btn-export-link').disabled = !ready;
+
+    // Record also needs WebCodecs
+    const hasWebCodecs = typeof VideoEncoder !== 'undefined';
+    document.getElementById('btn-export-record').disabled = !(ready && hasWebCodecs);
+}
+```
+
+**Step 3: Wire event listeners**
+
+Add at the bottom of app.js, in the event wiring section (after line 1841):
+
+```js
+// Export mode toggle
+document.getElementById('btn-export-mode').addEventListener('click', () => {
+    if (app.exportMode) {
+        app.exitExportMode();
+    } else {
+        app.enterExportMode();
+    }
+});
+
+// Draw buttons
+document.getElementById('btn-draw-polygon').addEventListener('click', () => {
+    if (app.map.draw) app.map.draw.changeMode('draw_polygon');
+});
+document.getElementById('btn-draw-rectangle').addEventListener('click', () => {
+    if (app.map.draw) app.map.draw.changeMode('draw_polygon');
+    // MapboxDraw doesn't have a built-in rectangle mode; use draw_polygon.
+    // For a true rectangle, we'd need a custom mode — polygon is fine for now.
+});
+document.getElementById('btn-draw-clear').addEventListener('click', () => {
+    app.map.clearDraw();
+    app.updateExportButtons();
+});
+
+// Date inputs update button state
+document.getElementById('export-date-start').addEventListener('change', () => app.updateExportButtons());
+document.getElementById('export-date-end').addEventListener('change', () => app.updateExportButtons());
+```
+
+**Step 4: Wire draw events to update state**
+
+In the `plowMap.on('load', ...)` handler (line 1850), add after the deck.gl overlay init:
+
+```js
+// Listen for Mapbox Draw events
+plowMap.on('draw.create', () => {
+    // Only allow one polygon at a time
+    const data = plowMap.draw?.getAll();
+    if (data && data.features.length > 1) {
+        const latest = data.features[data.features.length - 1];
+        plowMap.draw.deleteAll();
+        plowMap.draw.add(latest);
+    }
+    app.updateExportButtons();
+});
+plowMap.on('draw.update', () => app.updateExportButtons());
+plowMap.on('draw.delete', () => app.updateExportButtons());
+```
+
+**Step 5: Show "Export Region" button when in coverage mode**
+
+In the `enterCoverage()` method (line 1415), add:
+
+```js
+document.getElementById('btn-export-mode').style.display = 'block';
+```
+
+In the `enterRealtime()` method (line 1399), add:
+
+```js
+document.getElementById('btn-export-mode').style.display = 'none';
+if (this.exportMode) this.exitExportMode();
+```
+
+**Step 6: Test manually** — load the app, enter coverage mode, click "Export Region", draw a polygon, verify buttons enable/disable correctly.
+
+**Step 7: Commit**
+
+```bash
+git add src/where_the_plow/static/app.js
+git commit -m "feat: wire Mapbox Draw for region selection in export mode (#29)"
+```
+
+---
+
+### Task 4: Export preview — load spatially-filtered coverage and play back
+
+Wire the "Preview" button to load coverage data filtered to the drawn bbox and play it back using the existing playback system.
+
+**Files:**
+- Modify: `src/where_the_plow/static/app.js`
+
+**Step 1: Add preview method to PlowApp**
+
+```js
+async previewExport() {
+    const bbox = this.map.getDrawnBbox();
+    if (!bbox) return;
+    const startDate = document.getElementById('export-date-start').value;
+    const endDate = document.getElementById('export-date-end').value;
+    if (!startDate || !endDate) return;
+
+    const since = new Date(startDate + 'T00:00:00');
+    const until = new Date(endDate + 'T23:59:59');
+    const bboxParam = bbox.join(',');
+
+    // Store bbox for the fetch
+    this._exportBbox = bboxParam;
+
+    await this.loadCoverageForRange(since, until);
+
+    // Fit map to drawn region
+    const [west, south, east, north] = bbox;
+    this.map.map.fitBounds([[west, south], [east, north]], { padding: 50 });
+}
+```
+
+**Step 2: Modify `loadCoverageForRange` to include bbox**
+
+In `loadCoverageForRange()` (line 1438), modify the fetch URL to include bbox when available:
+
+```js
+let url = `/coverage?since=${since.toISOString()}&until=${until.toISOString()}`;
+if (this._exportBbox) {
+    url += `&bbox=${this._exportBbox}`;
+}
+const resp = await fetch(url, { signal });
+```
+
+**Step 3: Wire preview button**
+
+```js
+document.getElementById('btn-export-preview').addEventListener('click', () => {
+    app.previewExport();
+});
+```
+
+**Step 4: Test manually** — draw a region, set dates, click Preview, verify coverage loads filtered to the region and playback works.
+
+**Step 5: Commit**
+
+```bash
+git add src/where_the_plow/static/app.js
+git commit -m "feat: export preview loads spatially-filtered coverage (#29)"
+```
+
+---
+
+### Task 5: Shareable link — encode/decode replay state in URL params
+
+Add the ability to generate a shareable URL and to auto-load replay mode from URL params on page load.
+
+**Files:**
+- Modify: `src/where_the_plow/static/app.js`
+
+**Step 1: Add share link generation**
+
+Add to `PlowApp`:
+
+```js
+generateShareLink() {
+    const bbox = this.map.getDrawnBbox();
+    const startDate = document.getElementById('export-date-start').value;
+    const endDate = document.getElementById('export-date-end').value;
+    const speed = document.getElementById('export-speed').value;
+    const center = this.map.map.getCenter();
+    const zoom = this.map.map.getZoom().toFixed(2);
+
+    const params = new URLSearchParams({
+        mode: 'replay',
+        since: startDate,
+        until: endDate,
+        speed: speed,
+        center: `${center.lat.toFixed(4)},${center.lng.toFixed(4)}`,
+        zoom: zoom,
+    });
+    if (bbox) {
+        params.set('bbox', bbox.map(v => v.toFixed(6)).join(','));
+    }
+    const polygon = this.map.getDrawnPolygon();
+    if (polygon) {
+        params.set('polygon', JSON.stringify(polygon.geometry.coordinates[0]));
+    }
+
+    return `${window.location.origin}/?${params.toString()}`;
+}
+```
+
+**Step 2: Wire "Copy Link" button**
+
+```js
+document.getElementById('btn-export-link').addEventListener('click', () => {
+    const url = app.generateShareLink();
+    navigator.clipboard.writeText(url).then(() => {
+        const btn = document.getElementById('btn-export-link');
+        btn.textContent = 'Copied!';
+        setTimeout(() => { btn.textContent = 'Copy Link'; }, 2000);
+    });
+});
+```
+
+**Step 3: Add replay mode initialization**
+
+Add a function near the top of app.js (after the utility functions, before the PlowApp class):
+
+```js
+function parseReplayParams() {
+    const params = new URLSearchParams(window.location.search);
+    if (params.get('mode') !== 'replay') return null;
+    return {
+        since: params.get('since'),
+        until: params.get('until'),
+        speed: params.get('speed') || '30',
+        center: params.get('center'),
+        zoom: params.get('zoom'),
+        bbox: params.get('bbox'),
+        polygon: params.get('polygon'),
+    };
+}
+```
+
+**Step 4: Handle replay mode on app startup**
+
+In the `plowMap.on('load', ...)` handler (line 1850), after `app.startAutoRefresh()`, add:
+
+```js
+const replayParams = parseReplayParams();
+if (replayParams) {
+    // Skip welcome modal
+    document.getElementById('welcome-overlay').style.display = 'none';
+
+    // Switch to coverage mode
+    await app.switchMode('coverage');
+
+    // Set camera
+    if (replayParams.center && replayParams.zoom) {
+        const [lat, lng] = replayParams.center.split(',').map(Number);
+        plowMap.map.jumpTo({ center: [lng, lat], zoom: parseFloat(replayParams.zoom) });
+    }
+
+    // Load coverage with bbox
+    if (replayParams.since && replayParams.until) {
+        const since = new Date(replayParams.since + 'T00:00:00');
+        const until = new Date(replayParams.until + 'T23:59:59');
+        if (replayParams.bbox) {
+            app._exportBbox = replayParams.bbox;
+        }
+        await app.loadCoverageForRange(since, until);
+
+        // Draw polygon outline if provided
+        if (replayParams.polygon) {
+            try {
+                const coords = JSON.parse(replayParams.polygon);
+                // Add a visual-only polygon layer
+                plowMap.map.addSource('replay-polygon', {
+                    type: 'geojson',
+                    data: {
+                        type: 'Feature',
+                        geometry: { type: 'Polygon', coordinates: [coords] },
+                    },
+                });
+                plowMap.map.addLayer({
+                    id: 'replay-polygon-outline',
+                    type: 'line',
+                    source: 'replay-polygon',
+                    paint: {
+                        'line-color': '#fff',
+                        'line-width': 2,
+                        'line-dasharray': [3, 2],
+                        'line-opacity': 0.6,
+                    },
+                });
+            } catch (e) {
+                console.warn('Failed to parse replay polygon:', e);
+            }
+        }
+
+        // Set playback speed
+        playbackSpeedSelect.value = replayParams.speed;
+
+        // Auto-start playback
+        app.startPlayback();
+    }
+}
+```
+
+**Step 5: Test manually** — generate a link, open it in a new tab, verify it loads and auto-plays.
+
+**Step 6: Commit**
+
+```bash
+git add src/where_the_plow/static/app.js
+git commit -m "feat: shareable replay links with URL param encoding/decoding (#29)"
+```
+
+---
+
+### Task 6: Video recording pipeline with Mediabunny
+
+Implement the stepped-playback recording pipeline that captures the MapLibre canvas frame-by-frame and encodes to MP4 using Mediabunny.
+
+**Files:**
+- Modify: `src/where_the_plow/static/app.js`
+
+**Step 1: Add recording state and methods to PlowApp**
+
+Add to the constructor:
+
+```js
+// Recording
+this.recording = {
+    active: false,
+    cancelled: false,
+    output: null,
+    videoSource: null,
+};
+```
+
+**Step 2: Implement the recording method**
+
+Add to `PlowApp`:
+
+```js
+async startRecording() {
+    if (!window.Mediabunny) {
+        alert('Mediabunny not loaded yet. Please wait a moment and try again.');
+        return;
+    }
+    if (!this.coverageData || !this.deckTrips) {
+        alert('Load a preview first before recording.');
+        return;
+    }
+
+    const { Output, Mp4OutputFormat, BufferTarget, CanvasSource } = window.Mediabunny;
+
+    const mapCanvas = this.map.map.getCanvas();
+    const width = mapCanvas.width;
+    const height = mapCanvas.height;
+
+    // Create compositing canvas
+    const composite = document.createElement('canvas');
+    composite.width = width;
+    composite.height = height;
+    const ctx = composite.getContext('2d');
+
+    const videoSource = new CanvasSource(composite, {
+        codec: 'avc',
+        bitrate: 4_000_000,
+    });
+
+    const output = new Output({
+        format: new Mp4OutputFormat(),
+        target: new BufferTarget(),
+    });
+    output.addVideoTrack(videoSource, { frameRate: 30 });
+
+    this.recording = { active: true, cancelled: false, output, videoSource };
+
+    // UI
+    const progressEl = document.getElementById('export-progress');
+    const progressFill = document.getElementById('export-progress-fill');
+    const progressText = document.getElementById('export-progress-text');
+    const actionsEl = document.getElementById('export-actions');
+    progressEl.style.display = 'flex';
+    actionsEl.style.display = 'none';
+    this.lockPlaybackUI();
+
+    await output.start();
+
+    const fps = 30;
+    const durationSec = parseInt(document.getElementById('export-speed').value);
+    const totalFrames = fps * durationSec;
+    const sinceMs = this.coverageSince.getTime();
+    const untilMs = this.coverageUntil.getTime();
+    const rangeMs = untilMs - sinceMs;
+
+    try {
+        for (let i = 0; i < totalFrames; i++) {
+            if (this.recording.cancelled) break;
+
+            const progress = i / totalFrames;
+            const currentTimeMs = sinceMs + progress * rangeMs;
+
+            // Update slider to match
+            const sliderVal = (progress * 1000);
+            timeSliderEl.noUiSlider.set([0, sliderVal]);
+
+            // Render coverage at this time
+            this.renderCoverage(0, sliderVal);
+
+            // Wait a frame for WebGL to paint
+            await new Promise(r => requestAnimationFrame(r));
+            // Additional wait for deck.gl async rendering
+            await new Promise(r => setTimeout(r, 50));
+
+            // Composite: map + overlay
+            ctx.drawImage(mapCanvas, 0, 0);
+            this._drawRecordingOverlay(ctx, width, height, new Date(currentTimeMs));
+
+            // Feed frame to encoder
+            const timestamp = i / fps;
+            const duration = 1 / fps;
+            videoSource.add(timestamp, duration);
+
+            // Update progress
+            const pct = Math.round(progress * 100);
+            progressFill.style.width = pct + '%';
+            progressText.textContent = `Encoding: ${pct}%`;
+        }
+
+        if (!this.recording.cancelled) {
+            await output.finalize();
+
+            // Download
+            const blob = new Blob([output.target.buffer], { type: 'video/mp4' });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = 'plow-coverage.mp4';
+            a.click();
+            URL.revokeObjectURL(url);
+        } else {
+            await output.cancel();
+        }
+    } catch (err) {
+        console.error('Recording failed:', err);
+        try { await output.cancel(); } catch (_) {}
+        alert('Recording failed: ' + err.message);
+    }
+
+    // Restore UI
+    this.recording.active = false;
+    progressEl.style.display = 'none';
+    actionsEl.style.display = 'flex';
+    this.unlockPlaybackUI();
+}
+
+cancelRecording() {
+    this.recording.cancelled = true;
+}
+
+_drawRecordingOverlay(ctx, width, height, time) {
+    const fontSize = Math.max(14, Math.round(height / 40));
+    ctx.font = `${fontSize}px sans-serif`;
+    ctx.textBaseline = 'bottom';
+
+    // Timestamp — bottom left
+    const timeStr = time.toLocaleString(undefined, {
+        year: 'numeric', month: 'short', day: 'numeric',
+        hour: '2-digit', minute: '2-digit',
+    });
+    ctx.shadowColor = 'rgba(0,0,0,0.8)';
+    ctx.shadowBlur = 4;
+    ctx.fillStyle = '#fff';
+    ctx.textAlign = 'left';
+    ctx.fillText(timeStr, 12, height - 12);
+
+    // Branding — bottom right
+    ctx.textAlign = 'right';
+    ctx.fillText('plow.jackharrhy.dev', width - 12, height - 12);
+
+    // Reset shadow
+    ctx.shadowColor = 'transparent';
+    ctx.shadowBlur = 0;
+}
+```
+
+**Step 3: Wire recording buttons**
+
+```js
+document.getElementById('btn-export-record').addEventListener('click', () => {
+    app.startRecording();
+});
+document.getElementById('btn-export-cancel').addEventListener('click', () => {
+    app.cancelRecording();
+});
+```
+
+**Step 4: Test manually** — draw a region, set dates, click Preview to load data, click "Export MP4", verify progress bar works and an MP4 file downloads. Open the MP4 in a video player to verify it's valid.
+
+**Step 5: Commit**
+
+```bash
+git add src/where_the_plow/static/app.js
+git commit -m "feat: MP4 video recording pipeline with Mediabunny (#29)"
+```
+
+---
+
+### Task 7: Polish and edge cases
+
+Clean up UX, handle edge cases, and finalize the feature.
+
+**Files:**
+- Modify: `src/where_the_plow/static/app.js`
+- Modify: `src/where_the_plow/static/style.css`
+- Modify: `src/where_the_plow/static/index.html`
+
+**Step 1: Mobile guard**
+
+In `enterExportMode()`, add a check:
+
+```js
+if (window.innerWidth < 768) {
+    alert('Video export works best on desktop. Please use a larger screen.');
+    return;
+}
+```
+
+**Step 2: Disable map interaction during recording**
+
+In `startRecording()`, before the frame loop:
+
+```js
+this.map.map.getContainer().style.pointerEvents = 'none';
+```
+
+In cleanup (after the loop):
+
+```js
+this.map.map.getContainer().style.pointerEvents = '';
+```
+
+**Step 3: Clear `_exportBbox` when not in export mode**
+
+In `exitExportMode()`:
+
+```js
+this._exportBbox = null;
+```
+
+In `loadCoverageForRange()`, clear after the fetch so normal coverage loads aren't affected:
+
+After the fetch completes (before the transform), add a comment noting that `_exportBbox` is intentionally persistent during the export flow but cleared when exiting export mode.
+
+**Step 4: Google Analytics events**
+
+Add `gtag` calls for key actions:
+
+```js
+gtag('event', 'export_preview', { bbox: this._exportBbox });
+gtag('event', 'export_record_start');
+gtag('event', 'export_record_complete', { duration_sec: durationSec, frames: totalFrames });
+gtag('event', 'export_share_link');
+```
+
+**Step 5: Run all backend tests**
+
+Run: `uv run pytest -v`
+Expected: All PASS
+
+**Step 6: Commit**
+
+```bash
+git add src/where_the_plow/static/
+git commit -m "feat: export polish — mobile guard, analytics, UX improvements (#29)"
+```
+
+---
+
+### Task 8: Update README API table
+
+Add documentation for the new `bbox` parameter on the `/coverage` endpoint.
+
+**Files:**
+- Modify: `README.md`
+
+**Step 1: Update the API table**
+
+Find the `/coverage` row in the API endpoint table and add the `bbox` parameter to its description.
+
+**Step 2: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: document bbox parameter on /coverage endpoint (#29)"
+```

--- a/docs/plans/2026-02-26-smart-video-playback-design.md
+++ b/docs/plans/2026-02-26-smart-video-playback-design.md
@@ -1,0 +1,93 @@
+# Smart Video Playback — Design
+
+## Problem
+
+The current video export plays coverage trails at a uniform speed across the
+entire time range. This makes it hard to see _when_ plows were active vs idle.
+Multi-day ranges produce videos where most of the runtime shows nothing
+happening, and plow sessions fly by too fast.
+
+## Solution
+
+A "storytelling" video export that detects plow activity sessions within the
+selected region and plays them at variable speed:
+
+- **Active sessions** (plow in region) → steady pace showing trails
+- **Gap periods** (no plow) → fast-forward with elapsed counter, capped at 5s
+- **Footer** → color-coded timeline bar, timestamp, status, branding
+
+The video clearly communicates: when did plows come, how long did they stay,
+and how long were the gaps between visits.
+
+## Backend: Activity Segments Endpoint
+
+**`GET /coverage/segments`** — returns time segments for a bbox + time range.
+
+Query params:
+- `since` / `until` — ISO 8601 time range (same as /coverage)
+- `bbox` — required, `west,south,east,north`
+- `gap_threshold` — minutes, default 15
+
+Response:
+```json
+{
+  "segments": [
+    { "start": "...", "end": "...", "type": "gap" },
+    { "start": "...", "end": "...", "type": "active" }
+  ],
+  "gap_threshold_minutes": 15
+}
+```
+
+Logic: query all position timestamps within bbox + time range, sort, walk
+through — any gap > threshold starts a new segment. Leading/trailing gaps
+are included (from `since` to first position, last position to `until`).
+
+## Frontend: Smart Playback Engine
+
+### Time budget allocation
+
+User picks total video duration (e.g. 30s). Each segment gets allocated video
+time:
+
+- Active segments: proportional to real duration
+- Gap segments: proportional to real duration but at 100x speed, capped at 5s
+
+This means most of the video runtime shows actual plow activity.
+
+### During active segments
+
+- Map shows trails being drawn via existing `renderCoverage()`
+- Footer shows green dot + "Plow active" + session duration counter
+- Timestamp ticks at steady pace
+
+### During gap segments
+
+- Trails from previous session clear (renderCoverage with matching from/to
+  so trailLength=0, or clear layers entirely)
+- Footer shows grey "No plow — Xh Ym" with fast-ticking elapsed counter
+- Timestamp visibly fast-forwards
+- Timeline playhead races across the grey segment
+
+## Footer Visual Design
+
+80px tall bar drawn on the composite canvas below the map. Three rows:
+
+```
+┌─────────────────────────────────────────────────────┐
+│                    MAP AREA                          │
+├─────────────────────────────────────────────────────┤
+│ Feb 24 3:15 PM          ● Plow active    30m so far │
+│ [██████████░░░░░░▓▓▓▓▓▓▓░░░░░░░░░░░░░░░░░░░░░░░░░] │
+│ plow.jackharrhy.dev           Feb 24 – Feb 26, 2026 │
+└─────────────────────────────────────────────────────┘
+```
+
+- Row 1: current timestamp (left), status with colored dot (center), duration (right)
+- Row 2: timeline bar — green segments = active, dark grey = gaps, white playhead
+- Row 3: branding (left), date range (right)
+
+Colors: green `#4ade80`, dark grey `#374151`, white playhead.
+
+Composite canvas is map height + 80px. Map drawn into top portion, footer
+drawn into bottom 80px.

--- a/docs/plans/2026-02-26-smart-video-playback-impl.md
+++ b/docs/plans/2026-02-26-smart-video-playback-impl.md
@@ -1,0 +1,594 @@
+# Smart Video Playback Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Transform video export from uniform-speed playback into a storytelling visualization with variable speed (fast-forward gaps, steady active sessions) and a color-coded footer timeline.
+
+**Architecture:** New `/coverage/segments` backend endpoint returns activity segments (active/gap) for a bbox+time range. Frontend recording loop iterates segments instead of linear time, allocating video time proportionally. Footer with timeline bar is drawn on a taller composite canvas.
+
+**Tech Stack:** Python/FastAPI + DuckDB (backend), vanilla JS + MapLibre + deck.gl + Mediabunny (frontend)
+
+---
+
+### Task 1: Backend — `get_activity_segments()` DB method
+
+**Files:**
+- Modify: `src/where_the_plow/db.py` (add method after `get_coverage_trails` ~line 361)
+- Test: `tests/test_db.py` (add test at end of file)
+
+**Step 1: Write the failing test**
+
+Add to `tests/test_db.py`:
+
+```python
+def test_get_activity_segments():
+    db, path = make_db()
+    try:
+        now = datetime(2026, 2, 19, 12, 0, 0, tzinfo=timezone.utc)
+        db.upsert_vehicles([
+            {"vehicle_id": "v1", "description": "Plow 1", "vehicle_type": "SA PLOW TRUCK", "source": "st_johns"},
+        ])
+        # Session 1: 3 positions at 30s intervals starting at now
+        # Gap: 20 minutes (> 15min threshold)
+        # Session 2: 2 positions at 30s intervals starting at now+20min
+        positions = [
+            {"vehicle_id": "v1", "timestamp": now, "longitude": -52.73, "latitude": 47.56, "source": "st_johns"},
+            {"vehicle_id": "v1", "timestamp": now + timedelta(seconds=30), "longitude": -52.74, "latitude": 47.57, "source": "st_johns"},
+            {"vehicle_id": "v1", "timestamp": now + timedelta(seconds=60), "longitude": -52.75, "latitude": 47.58, "source": "st_johns"},
+            # 20 minute gap
+            {"vehicle_id": "v1", "timestamp": now + timedelta(minutes=20), "longitude": -52.73, "latitude": 47.56, "source": "st_johns"},
+            {"vehicle_id": "v1", "timestamp": now + timedelta(minutes=20, seconds=30), "longitude": -52.74, "latitude": 47.57, "source": "st_johns"},
+        ]
+        db.insert_positions(positions)
+
+        since = now - timedelta(minutes=5)
+        until = now + timedelta(minutes=25)
+        bbox = (-52.80, 47.50, -52.70, 47.60)
+
+        segments = db.get_activity_segments(since, until, bbox, gap_threshold_minutes=15)
+
+        # Expect: leading gap, session 1, gap, session 2, trailing gap
+        assert len(segments) == 5
+        assert segments[0]["type"] == "gap"     # since → first position
+        assert segments[1]["type"] == "active"   # session 1
+        assert segments[2]["type"] == "gap"      # between sessions
+        assert segments[3]["type"] == "active"   # session 2
+        assert segments[4]["type"] == "gap"      # last position → until
+
+        # Active segments should have correct boundaries
+        assert segments[1]["start"] == now.isoformat()
+        assert segments[1]["end"] == (now + timedelta(seconds=60)).isoformat()
+        assert segments[3]["start"] == (now + timedelta(minutes=20)).isoformat()
+        assert segments[3]["end"] == (now + timedelta(minutes=20, seconds=30)).isoformat()
+
+        # No activity → no segments (just one big gap)
+        far_bbox = (-50.0, 48.0, -49.0, 49.0)
+        segments_empty = db.get_activity_segments(since, until, far_bbox, gap_threshold_minutes=15)
+        assert len(segments_empty) == 1
+        assert segments_empty[0]["type"] == "gap"
+    finally:
+        db.close()
+        os.unlink(path)
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_db.py::test_get_activity_segments -v`
+Expected: FAIL — `AttributeError: 'Database' object has no attribute 'get_activity_segments'`
+
+**Step 3: Implement `get_activity_segments` in `db.py`**
+
+Add after `get_coverage_trails` method (~line 361):
+
+```python
+def get_activity_segments(
+    self,
+    since: datetime,
+    until: datetime,
+    bbox: tuple[float, float, float, float],
+    gap_threshold_minutes: int = 15,
+) -> list[dict]:
+    """Detect active/gap segments within a bbox for a time range.
+
+    Returns a list of {"start": iso, "end": iso, "type": "active"|"gap"}.
+    Active = positions present within gap_threshold. Gap = no positions.
+    Leading gap (since→first pos) and trailing gap (last pos→until) included.
+    """
+    west, south, east, north = bbox
+    rows = self.conn.execute(
+        """
+        SELECT timestamp
+        FROM positions
+        WHERE timestamp >= $1
+          AND timestamp <= $2
+          AND ST_Intersects(geom, ST_MakeEnvelope($3, $4, $5, $6))
+        ORDER BY timestamp
+        """,
+        [since, until, west, south, east, north],
+    ).fetchall()
+
+    if not rows:
+        return [{"start": since.isoformat(), "end": until.isoformat(), "type": "gap"}]
+
+    threshold = timedelta(minutes=gap_threshold_minutes)
+    segments = []
+
+    # Leading gap: since → first position
+    first_ts = rows[0][0]
+    if first_ts > since:
+        segments.append({"start": since.isoformat(), "end": first_ts.isoformat(), "type": "gap"})
+
+    # Walk through timestamps, group into active sessions
+    session_start = rows[0][0]
+    session_end = rows[0][0]
+
+    for i in range(1, len(rows)):
+        ts = rows[i][0]
+        if ts - session_end > threshold:
+            # End current active session
+            segments.append({"start": session_start.isoformat(), "end": session_end.isoformat(), "type": "active"})
+            # Add gap between sessions
+            segments.append({"start": session_end.isoformat(), "end": ts.isoformat(), "type": "gap"})
+            session_start = ts
+        session_end = ts
+
+    # Final active session
+    segments.append({"start": session_start.isoformat(), "end": session_end.isoformat(), "type": "active"})
+
+    # Trailing gap: last position → until
+    last_ts = rows[-1][0]
+    if last_ts < until:
+        segments.append({"start": last_ts.isoformat(), "end": until.isoformat(), "type": "gap"})
+
+    return segments
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_db.py::test_get_activity_segments -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```
+git add src/where_the_plow/db.py tests/test_db.py
+git commit -m "feat: add get_activity_segments DB method for plow session detection (#29)"
+```
+
+---
+
+### Task 2: Backend — `/coverage/segments` route
+
+**Files:**
+- Modify: `src/where_the_plow/routes.py` (add endpoint after `/coverage`)
+- Modify: `src/where_the_plow/models.py` (add response model)
+- Test: `tests/test_routes.py` (add route tests)
+
+**Step 1: Add Pydantic models in `models.py`**
+
+Add after `CoverageFeatureCollection` class:
+
+```python
+class ActivitySegment(BaseModel):
+    start: str = Field(..., description="ISO 8601 start time")
+    end: str = Field(..., description="ISO 8601 end time")
+    type: str = Field(..., description="'active' or 'gap'")
+
+class ActivitySegmentsResponse(BaseModel):
+    segments: list[ActivitySegment]
+    gap_threshold_minutes: int
+```
+
+**Step 2: Write the failing route test**
+
+Add to `tests/test_routes.py`:
+
+```python
+def test_get_coverage_segments(test_client):
+    """Segments endpoint returns activity/gap segments."""
+    client = test_client
+    # Use the seeded data: v1 has 3 positions at 30s intervals at 2026-02-19T12:00
+    # bbox around v1's area
+    resp = client.get(
+        "/coverage/segments",
+        params={
+            "since": "2026-02-19T11:00:00Z",
+            "until": "2026-02-19T13:00:00Z",
+            "bbox": "-52.80,47.50,-52.70,47.60",
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "segments" in data
+    assert "gap_threshold_minutes" in data
+    # Should have at least: leading gap, active session, trailing gap
+    types = [s["type"] for s in data["segments"]]
+    assert "active" in types
+    assert "gap" in types
+
+def test_get_coverage_segments_requires_bbox(test_client):
+    """Segments endpoint requires bbox parameter."""
+    client = test_client
+    resp = client.get(
+        "/coverage/segments",
+        params={"since": "2026-02-19T11:00:00Z", "until": "2026-02-19T13:00:00Z"},
+    )
+    assert resp.status_code == 422
+```
+
+**Step 3: Run tests to verify failure**
+
+Run: `uv run pytest tests/test_routes.py::test_get_coverage_segments tests/test_routes.py::test_get_coverage_segments_requires_bbox -v`
+Expected: FAIL — 404
+
+**Step 4: Implement the route**
+
+Add to `routes.py` after the `/coverage` endpoint:
+
+```python
+@router.get(
+    "/coverage/segments",
+    response_model=ActivitySegmentsResponse,
+    summary="Activity segments",
+    description="Detect plow activity sessions and gaps within a bounding box.",
+    tags=["coverage"],
+)
+def get_coverage_segments(
+    request: Request,
+    since: datetime | None = Query(None, description="Start of time range (ISO 8601). Default: 24 hours ago."),
+    until: datetime | None = Query(None, description="End of time range (ISO 8601). Default: now."),
+    bbox: str = Query(..., description="Required bounding box: west,south,east,north"),
+    gap_threshold: int = Query(15, description="Gap threshold in minutes", ge=1, le=120),
+):
+    if since is None:
+        since = datetime.now(timezone.utc) - timedelta(hours=24)
+    if until is None:
+        until = datetime.now(timezone.utc)
+
+    parts = bbox.split(",")
+    if len(parts) != 4:
+        raise HTTPException(status_code=422, detail="bbox must have 4 comma-separated values: west,south,east,north")
+    try:
+        bbox_tuple = tuple(float(p) for p in parts)
+    except ValueError:
+        raise HTTPException(status_code=422, detail="bbox values must be numbers")
+
+    west, south, east, north = bbox_tuple
+    if west >= east or south >= north:
+        raise HTTPException(status_code=422, detail="bbox must have west < east and south < north")
+
+    segments = db.get_activity_segments(since, until, bbox_tuple, gap_threshold_minutes=gap_threshold)
+    return ActivitySegmentsResponse(
+        segments=[ActivitySegment(**s) for s in segments],
+        gap_threshold_minutes=gap_threshold,
+    )
+```
+
+Add necessary imports: `ActivitySegment`, `ActivitySegmentsResponse` from models.
+
+**Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_routes.py::test_get_coverage_segments tests/test_routes.py::test_get_coverage_segments_requires_bbox -v`
+Expected: PASS
+
+**Step 6: Commit**
+
+```
+git add src/where_the_plow/routes.py src/where_the_plow/models.py tests/test_routes.py
+git commit -m "feat: add /coverage/segments endpoint for activity detection (#29)"
+```
+
+---
+
+### Task 3: Frontend — Fetch segments and compute video timeline
+
+**Files:**
+- Modify: `src/where_the_plow/static/app.js` — modify `startRecording()` setup
+
+**Step 1: Add segment fetch + time allocation logic**
+
+In `startRecording()`, after the existing `await output.start()` and before the frame loop, replace the simple linear time calculation with:
+
+```javascript
+// Fetch activity segments for this region + time range
+const segResp = await fetch(
+  `/coverage/segments?since=${this.coverageSince.toISOString()}&until=${this.coverageUntil.toISOString()}&bbox=${this._exportBbox}`
+);
+const segData = await segResp.json();
+const segments = segData.segments;
+
+// Compute video time allocation per segment
+const GAP_SPEED = 100;    // gaps play 100x faster than real time
+const GAP_CAP_SEC = 5;    // max 5 video-seconds per gap
+const fps = 30;
+
+// Calculate raw video seconds per segment
+const totalRangeMs = untilMs - sinceMs;
+let rawSegments = segments.map(seg => {
+  const startMs = new Date(seg.start).getTime();
+  const endMs = new Date(seg.end).getTime();
+  const realDurationMs = endMs - startMs;
+  let videoSec;
+  if (seg.type === 'gap') {
+    videoSec = Math.min(realDurationMs / 1000 / GAP_SPEED, GAP_CAP_SEC);
+  } else {
+    // Active segments: proportional share of user-chosen duration
+    videoSec = realDurationMs; // placeholder, will normalize
+  }
+  return { ...seg, startMs, endMs, realDurationMs, videoSec, type: seg.type };
+});
+
+// Normalize: fit everything into the user-chosen total duration
+const durationSec = parseInt(document.getElementById('export-speed').value);
+const totalGapVideoSec = rawSegments
+  .filter(s => s.type === 'gap')
+  .reduce((sum, s) => sum + s.videoSec, 0);
+const activeRealMs = rawSegments
+  .filter(s => s.type === 'active')
+  .reduce((sum, s) => sum + s.realDurationMs, 0);
+const activeVideoBudget = Math.max(1, durationSec - totalGapVideoSec);
+
+rawSegments = rawSegments.map(seg => {
+  if (seg.type === 'active' && activeRealMs > 0) {
+    seg.videoSec = activeVideoBudget * (seg.realDurationMs / activeRealMs);
+  }
+  seg.frameCount = Math.max(1, Math.round(seg.videoSec * fps));
+  return seg;
+});
+
+const totalFrames = rawSegments.reduce((sum, s) => sum + s.frameCount, 0);
+```
+
+**Step 2: Replace the frame loop**
+
+Replace the existing linear `for (let i = 0; ...)` frame loop with a segment-aware loop:
+
+```javascript
+let globalFrame = 0;
+for (const seg of rawSegments) {
+  if (this.recording.cancelled) break;
+
+  for (let f = 0; f < seg.frameCount; f++) {
+    if (this.recording.cancelled) break;
+
+    const segProgress = f / seg.frameCount;
+    const currentTimeMs = seg.startMs + segProgress * seg.realDurationMs;
+
+    // Map the time to slider value (0-1000)
+    const sliderVal = ((currentTimeMs - sinceMs) / totalRangeMs) * 1000;
+
+    // During gaps, clear trails; during active, show coverage
+    if (seg.type === 'gap') {
+      this.map.setDeckLayers([]);
+    } else {
+      timeSliderEl.noUiSlider.set([0, sliderVal]);
+      this.renderCoverage(0, sliderVal);
+    }
+
+    // Wait for MapLibre render
+    this.map.map.triggerRepaint();
+    await new Promise(r => this.map.map.once('render', r));
+    await new Promise(r => requestAnimationFrame(r));
+
+    // Composite: map + footer
+    ctx.drawImage(mapCanvas, 0, 0);
+    this._drawVideoFooter(ctx, width, compositeHeight, {
+      currentTimeMs,
+      segments: rawSegments,
+      sinceMs,
+      untilMs,
+      segment: seg,
+      segProgress,
+    });
+
+    // Feed frame
+    const timestamp = globalFrame / fps;
+    const duration = 1 / fps;
+    await videoSource.add(timestamp, duration);
+
+    // Progress
+    const pct = Math.round((globalFrame / totalFrames) * 100);
+    progressFill.style.width = pct + '%';
+    progressText.textContent = `Encoding: ${pct}%`;
+    globalFrame++;
+  }
+}
+```
+
+**Step 3: Commit**
+
+```
+git add src/where_the_plow/static/app.js
+git commit -m "feat: segment-aware recording loop with variable playback speed (#29)"
+```
+
+---
+
+### Task 4: Frontend — Footer drawing method
+
+**Files:**
+- Modify: `src/where_the_plow/static/app.js` — replace `_drawRecordingOverlay` with `_drawVideoFooter`
+
+**Step 1: Update composite canvas sizing**
+
+In `startRecording()`, change the composite canvas setup to be taller:
+
+```javascript
+const FOOTER_H = 80;
+const compositeHeight = height + FOOTER_H;
+const composite = document.createElement('canvas');
+composite.width = width;
+composite.height = compositeHeight;
+const ctx = composite.getContext('2d', { willReadFrequently: true });
+```
+
+Update the `CanvasSource` to use the larger canvas (it already does since it's passed `composite`).
+
+**Step 2: Implement `_drawVideoFooter`**
+
+Replace `_drawRecordingOverlay` with:
+
+```javascript
+_drawVideoFooter(ctx, width, compositeHeight, state) {
+  const { currentTimeMs, segments, sinceMs, untilMs, segment, segProgress } = state;
+  const FOOTER_H = 80;
+  const footerY = compositeHeight - FOOTER_H;
+  const totalRangeMs = untilMs - sinceMs;
+
+  // Footer background
+  ctx.fillStyle = '#1a1a2e';
+  ctx.fillRect(0, footerY, width, FOOTER_H);
+
+  // Border line at top of footer
+  ctx.strokeStyle = 'rgba(255,255,255,0.15)';
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  ctx.moveTo(0, footerY);
+  ctx.lineTo(width, footerY);
+  ctx.stroke();
+
+  const pad = 12;
+  const fontSize = Math.max(12, Math.round(FOOTER_H / 6));
+
+  // Row 1: timestamp (left), status (center-right), duration (right)
+  ctx.font = `${fontSize}px sans-serif`;
+  ctx.textBaseline = 'top';
+  ctx.fillStyle = '#e2e8f0';
+
+  const time = new Date(currentTimeMs);
+  const timeStr = time.toLocaleString(undefined, {
+    month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit',
+  });
+  ctx.textAlign = 'left';
+  ctx.fillText(timeStr, pad, footerY + 6);
+
+  // Status indicator
+  const isActive = segment.type === 'active';
+  const dotColor = isActive ? '#4ade80' : '#6b7280';
+  const statusText = isActive
+    ? 'Plow active'
+    : `No plow — ${this._formatDuration(segment.realDurationMs)}`;
+
+  const statusX = width / 2;
+  ctx.textAlign = 'center';
+  // Draw dot
+  ctx.fillStyle = dotColor;
+  ctx.beginPath();
+  const dotY = footerY + 6 + fontSize / 2;
+  const dotR = fontSize / 3;
+  const textMetrics = ctx.measureText(statusText);
+  const dotOffsetX = statusX - textMetrics.width / 2 - dotR - 6;
+  ctx.arc(dotOffsetX, dotY, dotR, 0, Math.PI * 2);
+  ctx.fill();
+  // Status text
+  ctx.fillStyle = isActive ? '#4ade80' : '#9ca3af';
+  ctx.fillText(statusText, statusX, footerY + 6);
+
+  // Session elapsed (right side)
+  if (isActive) {
+    const elapsed = currentTimeMs - segment.startMs;
+    ctx.textAlign = 'right';
+    ctx.fillStyle = '#e2e8f0';
+    ctx.fillText(this._formatDuration(elapsed) + ' so far', width - pad, footerY + 6);
+  }
+
+  // Row 2: Timeline bar
+  const barY = footerY + 6 + fontSize + 6;
+  const barH = 10;
+  const barX = pad;
+  const barW = width - 2 * pad;
+
+  // Draw segment colors
+  for (const seg of segments) {
+    const x0 = barX + ((seg.startMs - sinceMs) / totalRangeMs) * barW;
+    const x1 = barX + ((seg.endMs - sinceMs) / totalRangeMs) * barW;
+    ctx.fillStyle = seg.type === 'active' ? '#4ade80' : '#374151';
+    ctx.fillRect(x0, barY, x1 - x0, barH);
+  }
+
+  // Playhead
+  const playX = barX + ((currentTimeMs - sinceMs) / totalRangeMs) * barW;
+  ctx.fillStyle = '#ffffff';
+  ctx.fillRect(playX - 1, barY - 2, 2, barH + 4);
+
+  // Row 3: branding (left), date range (right)
+  const row3Y = barY + barH + 6;
+  ctx.font = `${Math.max(10, fontSize - 2)}px sans-serif`;
+  ctx.fillStyle = '#9ca3af';
+  ctx.textAlign = 'left';
+  ctx.fillText('plow.jackharrhy.dev', pad, row3Y);
+
+  ctx.textAlign = 'right';
+  const sinceDate = new Date(sinceMs);
+  const untilDate = new Date(untilMs);
+  const rangeStr = sinceDate.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+    + ' – ' + untilDate.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+  ctx.fillText(rangeStr, width - pad, row3Y);
+}
+
+_formatDuration(ms) {
+  const totalMin = Math.floor(ms / 60000);
+  const hours = Math.floor(totalMin / 60);
+  const mins = totalMin % 60;
+  if (hours > 0) return `${hours}h ${mins}m`;
+  return `${mins}m`;
+}
+```
+
+**Step 3: Commit**
+
+```
+git add src/where_the_plow/static/app.js
+git commit -m "feat: add video footer with color-coded timeline bar and status (#29)"
+```
+
+---
+
+### Task 5: Frontend — Clean up old overlay, update README
+
+**Files:**
+- Modify: `src/where_the_plow/static/app.js` — remove old `_drawRecordingOverlay` if not used elsewhere
+- Modify: `README.md` — add `/coverage/segments` to API table
+
+**Step 1: Remove `_drawRecordingOverlay`**
+
+Delete the old method (lines ~2042-2065) since it's replaced by `_drawVideoFooter`.
+
+**Step 2: Update README API table**
+
+Add to the API endpoint table:
+
+```
+| GET    | `/coverage/segments` | Activity segments for a region | `since`, `until`, `bbox` (required), `gap_threshold` |
+```
+
+**Step 3: Run all tests**
+
+Run: `uv run pytest -v`
+Expected: All tests pass
+
+**Step 4: Commit**
+
+```
+git add src/where_the_plow/static/app.js README.md
+git commit -m "chore: remove old overlay method, document /coverage/segments endpoint (#29)"
+```
+
+---
+
+### Task 6: Integration pass — test full flow manually
+
+This is a manual testing task:
+
+1. Load the app, enter export mode, draw a polygon
+2. Set a multi-day date range and click Preview
+3. Click Record — verify:
+   - Video shows footer with timeline bar
+   - Gaps fast-forward visibly (timestamp jumps)
+   - Active sessions show trails being drawn at readable pace
+   - Footer status indicator toggles green/grey
+   - Playhead moves along timeline bar
+   - Branding and date range visible
+4. Download video and verify it plays correctly
+
+No code changes unless issues found.

--- a/src/where_the_plow/db.py
+++ b/src/where_the_plow/db.py
@@ -278,6 +278,7 @@ class Database:
         since: datetime,
         until: datetime,
         source: str | None = None,
+        bbox: tuple[float, float, float, float] | None = None,
     ) -> list[dict]:
         """Get per-vehicle LineString trails in a time range.
 
@@ -290,6 +291,11 @@ class Database:
         if source is not None:
             source_filter = f"AND p.source = ${len(params) + 1}"
             params.append(source)
+        bbox_filter = ""
+        if bbox is not None:
+            west, south, east, north = bbox
+            bbox_filter = f"AND ST_Intersects(p.geom, ST_MakeEnvelope(${len(params) + 1}, ${len(params) + 2}, ${len(params) + 3}, ${len(params) + 4}))"
+            params.extend([west, south, east, north])
         query = f"""
             WITH with_gap AS (
                 SELECT
@@ -308,6 +314,7 @@ class Database:
                 WHERE p.timestamp >= $1
                 AND p.timestamp <= $2
                 {source_filter}
+                {bbox_filter}
             ),
             with_segment AS (
                 SELECT *,

--- a/src/where_the_plow/db.py
+++ b/src/where_the_plow/db.py
@@ -3,7 +3,7 @@ import os
 from pathlib import Path
 
 import duckdb
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from itertools import groupby
 
 
@@ -359,6 +359,102 @@ class Database:
             )
 
         return trails
+
+    def get_activity_segments(
+        self,
+        since: datetime,
+        until: datetime,
+        bbox: tuple[float, float, float, float],
+        gap_threshold_minutes: int = 15,
+    ) -> list[dict]:
+        """Return active/gap segments for positions within bbox and time range.
+
+        Walks through timestamps sorted chronologically; any gap larger than
+        gap_threshold_minutes starts a new segment.  Leading and trailing
+        gaps (since→first position, last position→until) are included.
+        If no positions match, returns a single gap spanning the full range.
+        """
+        west, south, east, north = bbox
+        params: list = [since, until, west, south, east, north]
+        query = """
+            SELECT DISTINCT timestamp
+            FROM positions
+            WHERE timestamp >= $1
+              AND timestamp <= $2
+              AND ST_Intersects(geom, ST_MakeEnvelope($3, $4, $5, $6))
+            ORDER BY timestamp
+        """
+        rows = self._cursor().execute(query, params).fetchall()
+        timestamps: list[datetime] = [r[0].astimezone(timezone.utc) for r in rows]
+
+        if not timestamps:
+            return [
+                {
+                    "start": since.isoformat(),
+                    "end": until.isoformat(),
+                    "type": "gap",
+                }
+            ]
+
+        gap_threshold = timedelta(minutes=gap_threshold_minutes)
+        segments: list[dict] = []
+
+        # Leading gap: since → first position
+        if timestamps[0] > since:
+            segments.append(
+                {
+                    "start": since.isoformat(),
+                    "end": timestamps[0].isoformat(),
+                    "type": "gap",
+                }
+            )
+
+        # Walk through timestamps, splitting on gaps
+        seg_start = timestamps[0]
+        seg_end = timestamps[0]
+
+        for i in range(1, len(timestamps)):
+            gap = timestamps[i] - timestamps[i - 1]
+            if gap > gap_threshold:
+                # Close current active segment
+                segments.append(
+                    {
+                        "start": seg_start.isoformat(),
+                        "end": seg_end.isoformat(),
+                        "type": "active",
+                    }
+                )
+                # Insert gap segment
+                segments.append(
+                    {
+                        "start": seg_end.isoformat(),
+                        "end": timestamps[i].isoformat(),
+                        "type": "gap",
+                    }
+                )
+                seg_start = timestamps[i]
+            seg_end = timestamps[i]
+
+        # Close final active segment
+        segments.append(
+            {
+                "start": seg_start.isoformat(),
+                "end": seg_end.isoformat(),
+                "type": "active",
+            }
+        )
+
+        # Trailing gap: last position → until
+        if timestamps[-1] < until:
+            segments.append(
+                {
+                    "start": timestamps[-1].isoformat(),
+                    "end": until.isoformat(),
+                    "type": "gap",
+                }
+            )
+
+        return segments
 
     def _row_to_dict(self, row) -> dict:
         return {

--- a/src/where_the_plow/models.py
+++ b/src/where_the_plow/models.py
@@ -93,6 +93,17 @@ class CoverageFeatureCollection(BaseModel):
     features: list[CoverageFeature]
 
 
+class ActivitySegment(BaseModel):
+    start: str = Field(..., description="ISO 8601 start time")
+    end: str = Field(..., description="ISO 8601 end time")
+    type: str = Field(..., description="'active' or 'gap'")
+
+
+class ActivitySegmentsResponse(BaseModel):
+    segments: list[ActivitySegment]
+    gap_threshold_minutes: int
+
+
 class ViewportTrack(BaseModel):
     zoom: float = Field(..., description="Current map zoom level")
     center: list[float] = Field(

--- a/src/where_the_plow/routes.py
+++ b/src/where_the_plow/routes.py
@@ -47,14 +47,14 @@ _search_limiter = RateLimiter(
 _COVERAGE_TTL = 5 * 60  # 5 minutes — matches frontend rounding interval
 _COVERAGE_MAX = 20  # max entries before evicting oldest
 
-# key = (since_iso, until_iso, source|None)  ->  (expires_at_monotonic, trails)
+# key = (since_iso, until_iso, source|None, bbox|None)  ->  (expires_at_monotonic, trails)
 _coverage_cache: dict[tuple, tuple[float, list[dict]]] = {}
 
 
 def _coverage_cache_get(
-    since: datetime, until: datetime, source: str | None
+    since: datetime, until: datetime, source: str | None, bbox: str | None = None
 ) -> list[dict] | None:
-    key = (since.isoformat(), until.isoformat(), source)
+    key = (since.isoformat(), until.isoformat(), source, bbox)
     entry = _coverage_cache.get(key)
     if entry is None:
         return None
@@ -66,9 +66,13 @@ def _coverage_cache_get(
 
 
 def _coverage_cache_put(
-    since: datetime, until: datetime, source: str | None, trails: list[dict]
+    since: datetime,
+    until: datetime,
+    source: str | None,
+    trails: list[dict],
+    bbox: str | None = None,
 ) -> None:
-    key = (since.isoformat(), until.isoformat(), source)
+    key = (since.isoformat(), until.isoformat(), source, bbox)
     # Evict oldest if full
     if len(_coverage_cache) >= _COVERAGE_MAX and key not in _coverage_cache:
         oldest_key = min(_coverage_cache, key=lambda k: _coverage_cache[k][0])
@@ -360,6 +364,10 @@ def get_coverage(
         None,
         description="Filter by data source (e.g. 'st_johns', 'mt_pearl', 'provincial')",
     ),
+    bbox: str | None = Query(
+        None,
+        description="Bounding box filter: west,south,east,north (e.g. '-52.8,47.5,-52.7,47.6')",
+    ),
 ):
     db = request.app.state.db
     now = datetime.now(timezone.utc)
@@ -368,21 +376,39 @@ def get_coverage(
     if until is None:
         until = now
 
+    bbox_tuple = None
+    if bbox is not None:
+        try:
+            parts = [float(x) for x in bbox.split(",")]
+            if len(parts) != 4:
+                raise ValueError
+            bbox_tuple = tuple(parts)
+        except ValueError:
+            return JSONResponse(
+                status_code=422,
+                content={
+                    "detail": "bbox must be 4 comma-separated floats: west,south,east,north"
+                },
+            )
+
     # 1. In-memory cache (short TTL, works for recent/live queries)
-    trails = _coverage_cache_get(since, until, source)
+    trails = _coverage_cache_get(since, until, source, bbox)
     if trails is None:
-        # 2. File cache (historical queries only, no source filter)
-        if source is None:
+        # 2. File cache (historical queries only, no source/bbox filter)
+        if source is None and bbox is None:
             trails = cache.get(since, until)
         if trails is None:
             trails = db.get_coverage_trails(
-                since=since, until=until, **({"source": source} if source else {})
+                since=since,
+                until=until,
+                **({"source": source} if source else {}),
+                **({"bbox": bbox_tuple} if bbox_tuple else {}),
             )
-            # Populate file cache for historical queries
-            if source is None:
+            # Populate file cache for historical queries (unfiltered only)
+            if source is None and bbox is None:
                 cache.put(since, until, trails)
         # Populate in-memory cache for all queries
-        _coverage_cache_put(since, until, source, trails)
+        _coverage_cache_put(since, until, source, trails, bbox)
 
     features = [
         CoverageFeature(

--- a/src/where_the_plow/routes.py
+++ b/src/where_the_plow/routes.py
@@ -382,6 +382,8 @@ def get_coverage(
             parts = [float(x) for x in bbox.split(",")]
             if len(parts) != 4:
                 raise ValueError
+            if parts[0] >= parts[2] or parts[1] >= parts[3]:
+                raise ValueError
             bbox_tuple = tuple(parts)
         except ValueError:
             return JSONResponse(

--- a/src/where_the_plow/routes.py
+++ b/src/where_the_plow/routes.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 from datetime import datetime, timezone, timedelta
 
 import httpx
-from fastapi import APIRouter, Query, Request, Response
+from fastapi import APIRouter, HTTPException, Query, Request, Response
 from fastapi.responses import JSONResponse
 
 from where_the_plow import cache
@@ -120,6 +120,8 @@ def _client_ip(request: Request) -> str:
 
 
 from where_the_plow.models import (
+    ActivitySegment,
+    ActivitySegmentsResponse,
     CoverageFeature,
     CoverageFeatureCollection,
     CoverageProperties,
@@ -426,6 +428,58 @@ def get_coverage(
         for t in trails
     ]
     return CoverageFeatureCollection(features=features)
+
+
+@router.get(
+    "/coverage/segments",
+    response_model=ActivitySegmentsResponse,
+    summary="Activity segments",
+    description="Detect plow activity sessions and gaps within a bounding box.",
+    tags=["coverage"],
+)
+def get_coverage_segments(
+    request: Request,
+    since: datetime | None = Query(
+        None, description="Start of time range (ISO 8601). Default: 24 hours ago."
+    ),
+    until: datetime | None = Query(
+        None, description="End of time range (ISO 8601). Default: now."
+    ),
+    bbox: str = Query(..., description="Required bounding box: west,south,east,north"),
+    gap_threshold: int = Query(
+        15, description="Gap threshold in minutes", ge=1, le=120
+    ),
+):
+    if since is None:
+        since = datetime.now(timezone.utc) - timedelta(hours=24)
+    if until is None:
+        until = datetime.now(timezone.utc)
+
+    parts = bbox.split(",")
+    if len(parts) != 4:
+        raise HTTPException(
+            status_code=422,
+            detail="bbox must have 4 comma-separated values: west,south,east,north",
+        )
+    try:
+        bbox_tuple = tuple(float(p) for p in parts)
+    except ValueError:
+        raise HTTPException(status_code=422, detail="bbox values must be numbers")
+
+    west, south, east, north = bbox_tuple
+    if west >= east or south >= north:
+        raise HTTPException(
+            status_code=422, detail="bbox must have west < east and south < north"
+        )
+
+    db = request.app.state.db
+    segments = db.get_activity_segments(
+        since, until, bbox_tuple, gap_threshold_minutes=gap_threshold
+    )
+    return ActivitySegmentsResponse(
+        segments=[ActivitySegment(**s) for s in segments],
+        gap_threshold_minutes=gap_threshold,
+    )
 
 
 @router.get(

--- a/src/where_the_plow/static/app.js
+++ b/src/where_the_plow/static/app.js
@@ -1931,11 +1931,13 @@ class PlowApp {
     const mapCanvas = this.map.map.getCanvas();
     const width = mapCanvas.width;
     const height = mapCanvas.height;
+    const FOOTER_H = 80;
+    const compositeHeight = height + FOOTER_H;
 
-    // Create compositing canvas
+    // Create compositing canvas (map + footer)
     const composite = document.createElement('canvas');
     composite.width = width;
-    composite.height = height;
+    composite.height = compositeHeight;
     const ctx = composite.getContext('2d', { willReadFrequently: true });
 
     const videoSource = new CanvasSource(composite, {
@@ -1965,45 +1967,102 @@ class PlowApp {
     await output.start();
 
     const fps = 30;
-    const durationSec = parseInt(document.getElementById('export-speed').value);
-    const totalFrames = fps * durationSec;
     const sinceMs = this.coverageSince.getTime();
     const untilMs = this.coverageUntil.getTime();
-    const rangeMs = untilMs - sinceMs;
+    const totalRangeMs = untilMs - sinceMs;
+
+    // Fetch activity segments for this region + time range
+    const segResp = await fetch(
+      `/coverage/segments?since=${this.coverageSince.toISOString()}&until=${this.coverageUntil.toISOString()}&bbox=${this._exportBbox}`
+    );
+    const segData = await segResp.json();
+
+    // Compute video time allocation per segment
+    const GAP_SPEED = 100;
+    const GAP_CAP_SEC = 5;
+    const durationSec = parseInt(document.getElementById('export-speed').value);
+
+    let rawSegments = segData.segments.map(seg => {
+      const startMs = new Date(seg.start).getTime();
+      const endMs = new Date(seg.end).getTime();
+      const realDurationMs = endMs - startMs;
+      let videoSec;
+      if (seg.type === 'gap') {
+        videoSec = Math.min(realDurationMs / 1000 / GAP_SPEED, GAP_CAP_SEC);
+      } else {
+        videoSec = realDurationMs; // placeholder, will normalize below
+      }
+      return { ...seg, startMs, endMs, realDurationMs, videoSec };
+    });
+
+    // Normalize: fit into user-chosen total duration
+    const totalGapVideoSec = rawSegments
+      .filter(s => s.type === 'gap')
+      .reduce((sum, s) => sum + s.videoSec, 0);
+    const activeRealMs = rawSegments
+      .filter(s => s.type === 'active')
+      .reduce((sum, s) => sum + s.realDurationMs, 0);
+    const activeVideoBudget = Math.max(1, durationSec - totalGapVideoSec);
+
+    rawSegments = rawSegments.map(seg => {
+      if (seg.type === 'active' && activeRealMs > 0) {
+        seg.videoSec = activeVideoBudget * (seg.realDurationMs / activeRealMs);
+      }
+      seg.frameCount = Math.max(1, Math.round(seg.videoSec * fps));
+      return seg;
+    });
+
+    const totalFrames = rawSegments.reduce((sum, s) => sum + s.frameCount, 0);
 
     try {
-      for (let i = 0; i < totalFrames; i++) {
+      let globalFrame = 0;
+      for (const seg of rawSegments) {
         if (this.recording.cancelled) break;
 
-        const progress = i / totalFrames;
-        const currentTimeMs = sinceMs + progress * rangeMs;
+        for (let f = 0; f < seg.frameCount; f++) {
+          if (this.recording.cancelled) break;
 
-        // Update slider to match
-        const sliderVal = progress * 1000;
-        timeSliderEl.noUiSlider.set([0, sliderVal]);
+          const segProgress = f / seg.frameCount;
+          const currentTimeMs = seg.startMs + segProgress * seg.realDurationMs;
 
-        // Render coverage at this time
-        this.renderCoverage(0, sliderVal);
+          // Map the time to slider value (0-1000)
+          const sliderVal = ((currentTimeMs - sinceMs) / totalRangeMs) * 1000;
 
-        // Force MapLibre to render and wait for the frame to actually paint
-        this.map.map.triggerRepaint();
-        await new Promise(r => this.map.map.once('render', r));
-        // Extra rAF to ensure the WebGL draw commands are flushed
-        await new Promise(r => requestAnimationFrame(r));
+          // During gaps, clear trails; during active, show coverage
+          if (seg.type === 'gap') {
+            this.map.setDeckLayers([]);
+          } else {
+            timeSliderEl.noUiSlider.set([0, sliderVal]);
+            this.renderCoverage(0, sliderVal);
+          }
 
-        // Composite: map + overlay
-        ctx.drawImage(mapCanvas, 0, 0);
-        this._drawRecordingOverlay(ctx, width, height, new Date(currentTimeMs));
+          // Wait for MapLibre render
+          this.map.map.triggerRepaint();
+          await new Promise(r => this.map.map.once('render', r));
+          await new Promise(r => requestAnimationFrame(r));
 
-        // Feed frame to encoder
-        const timestamp = i / fps;
-        const duration = 1 / fps;
-        await videoSource.add(timestamp, duration);
+          // Composite: map + footer
+          ctx.drawImage(mapCanvas, 0, 0);
+          this._drawVideoFooter(ctx, width, compositeHeight, {
+            currentTimeMs,
+            segments: rawSegments,
+            sinceMs,
+            untilMs,
+            segment: seg,
+            segProgress,
+          });
 
-        // Update progress
-        const pct = Math.round(progress * 100);
-        progressFill.style.width = pct + '%';
-        progressText.textContent = `Encoding: ${pct}%`;
+          // Feed frame
+          const timestamp = globalFrame / fps;
+          const duration = 1 / fps;
+          await videoSource.add(timestamp, duration);
+
+          // Progress
+          const pct = Math.round((globalFrame / totalFrames) * 100);
+          progressFill.style.width = pct + '%';
+          progressText.textContent = `Encoding: ${pct}%`;
+          globalFrame++;
+        }
       }
 
       if (!this.recording.cancelled) {
@@ -2039,29 +2098,109 @@ class PlowApp {
     this.recording.cancelled = true;
   }
 
-  _drawRecordingOverlay(ctx, width, height, time) {
-    const fontSize = Math.max(14, Math.round(height / 40));
+  _drawVideoFooter(ctx, width, compositeHeight, state) {
+    const { currentTimeMs, segments, sinceMs, untilMs, segment, segProgress } = state;
+    const FOOTER_H = 80;
+    const footerY = compositeHeight - FOOTER_H;
+    const totalRangeMs = untilMs - sinceMs;
+
+    // Footer background
+    ctx.fillStyle = '#1a1a2e';
+    ctx.fillRect(0, footerY, width, FOOTER_H);
+
+    // Border line at top of footer
+    ctx.strokeStyle = 'rgba(255,255,255,0.15)';
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(0, footerY);
+    ctx.lineTo(width, footerY);
+    ctx.stroke();
+
+    const pad = 12;
+    const fontSize = Math.max(12, Math.round(FOOTER_H / 6));
+
+    // Row 1: timestamp (left), status (center), elapsed (right)
     ctx.font = `${fontSize}px sans-serif`;
-    ctx.textBaseline = 'bottom';
+    ctx.textBaseline = 'top';
+    ctx.fillStyle = '#e2e8f0';
 
-    // Timestamp — bottom left
+    const time = new Date(currentTimeMs);
     const timeStr = time.toLocaleString(undefined, {
-      year: 'numeric', month: 'short', day: 'numeric',
-      hour: '2-digit', minute: '2-digit',
+      month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit',
     });
-    ctx.shadowColor = 'rgba(0,0,0,0.8)';
-    ctx.shadowBlur = 4;
-    ctx.fillStyle = '#fff';
     ctx.textAlign = 'left';
-    ctx.fillText(timeStr, 12, height - 12);
+    ctx.fillText(timeStr, pad, footerY + 6);
 
-    // Branding — bottom right
+    // Status indicator
+    const isActive = segment.type === 'active';
+    const dotColor = isActive ? '#4ade80' : '#6b7280';
+    const statusText = isActive
+      ? 'Plow active'
+      : `No plow \u2014 ${this._formatDuration(segment.realDurationMs)}`;
+
+    const statusX = width / 2;
+    ctx.textAlign = 'center';
+    // Draw dot
+    ctx.fillStyle = dotColor;
+    ctx.beginPath();
+    const dotY = footerY + 6 + fontSize / 2;
+    const dotR = fontSize / 3;
+    const textMetrics = ctx.measureText(statusText);
+    const dotOffsetX = statusX - textMetrics.width / 2 - dotR - 6;
+    ctx.arc(dotOffsetX, dotY, dotR, 0, Math.PI * 2);
+    ctx.fill();
+    // Status text
+    ctx.fillStyle = isActive ? '#4ade80' : '#9ca3af';
+    ctx.fillText(statusText, statusX, footerY + 6);
+
+    // Session elapsed (right side)
+    if (isActive) {
+      const elapsed = currentTimeMs - segment.startMs;
+      ctx.textAlign = 'right';
+      ctx.fillStyle = '#e2e8f0';
+      ctx.fillText(this._formatDuration(elapsed) + ' so far', width - pad, footerY + 6);
+    }
+
+    // Row 2: Timeline bar
+    const barY = footerY + 6 + fontSize + 6;
+    const barH = 10;
+    const barX = pad;
+    const barW = width - 2 * pad;
+
+    // Draw segment colors
+    for (const seg of segments) {
+      const x0 = barX + ((seg.startMs - sinceMs) / totalRangeMs) * barW;
+      const x1 = barX + ((seg.endMs - sinceMs) / totalRangeMs) * barW;
+      ctx.fillStyle = seg.type === 'active' ? '#4ade80' : '#374151';
+      ctx.fillRect(x0, barY, Math.max(1, x1 - x0), barH);
+    }
+
+    // Playhead
+    const playX = barX + ((currentTimeMs - sinceMs) / totalRangeMs) * barW;
+    ctx.fillStyle = '#ffffff';
+    ctx.fillRect(playX - 1, barY - 2, 2, barH + 4);
+
+    // Row 3: branding (left), date range (right)
+    const row3Y = barY + barH + 6;
+    ctx.font = `${Math.max(10, fontSize - 2)}px sans-serif`;
+    ctx.fillStyle = '#9ca3af';
+    ctx.textAlign = 'left';
+    ctx.fillText('plow.jackharrhy.dev', pad, row3Y);
+
     ctx.textAlign = 'right';
-    ctx.fillText('plow.jackharrhy.dev', width - 12, height - 12);
+    const sinceDate = new Date(sinceMs);
+    const untilDate = new Date(untilMs);
+    const rangeStr = sinceDate.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+      + ' \u2013 ' + untilDate.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+    ctx.fillText(rangeStr, width - pad, row3Y);
+  }
 
-    // Reset shadow
-    ctx.shadowColor = 'transparent';
-    ctx.shadowBlur = 0;
+  _formatDuration(ms) {
+    const totalMin = Math.floor(ms / 60000);
+    const hours = Math.floor(totalMin / 60);
+    const mins = totalMin % 60;
+    if (hours > 0) return `${hours}h ${mins}m`;
+    return `${mins}m`;
   }
 }
 

--- a/src/where_the_plow/static/app.js
+++ b/src/where_the_plow/static/app.js
@@ -1493,10 +1493,11 @@ class PlowApp {
     timeSliderEl.noUiSlider.set([0, 1000]);
     this.map.clearCoverage();
     try {
-      const resp = await fetch(
-        `/coverage?since=${since.toISOString()}&until=${until.toISOString()}`,
-        { signal },
-      );
+      let url = `/coverage?since=${since.toISOString()}&until=${until.toISOString()}`;
+      if (this._exportBbox) {
+        url += `&bbox=${this._exportBbox}`;
+      }
+      const resp = await fetch(url, { signal });
       this.coverageData = await resp.json();
       // Pre-parse timestamp strings to epoch ms (once, not per frame)
       const baseTime = since.getTime();
@@ -1808,6 +1809,7 @@ class PlowApp {
 
   exitExportMode() {
     this.exportMode = false;
+    this._exportBbox = null;
     this.map.clearDraw();
     if (this.map.draw) {
       this.map.map.removeControl(this.map.draw);
@@ -1817,6 +1819,27 @@ class PlowApp {
     document.getElementById('btn-export-mode').textContent = 'Export Region';
     document.getElementById('export-unsupported').style.display = 'none';
     this.exportPolygon = null;
+  }
+
+  async previewExport() {
+    const bbox = this.map.getDrawnBbox();
+    if (!bbox) return;
+    const startDate = document.getElementById('export-date-start').value;
+    const endDate = document.getElementById('export-date-end').value;
+    if (!startDate || !endDate) return;
+
+    const since = new Date(startDate + 'T00:00:00');
+    const until = new Date(endDate + 'T23:59:59');
+    const bboxParam = bbox.join(',');
+
+    // Store bbox for the fetch
+    this._exportBbox = bboxParam;
+
+    await this.loadCoverageForRange(since, until);
+
+    // Fit map to drawn region
+    const [west, south, east, north] = bbox;
+    this.map.map.fitBounds([[west, south], [east, north]], { padding: 50 });
   }
 
   updateExportButtons() {
@@ -1966,6 +1989,11 @@ document.getElementById('btn-draw-clear').addEventListener('click', () => {
 // Export date inputs update button state
 document.getElementById('export-date-start').addEventListener('change', () => app.updateExportButtons());
 document.getElementById('export-date-end').addEventListener('change', () => app.updateExportButtons());
+
+// Export preview
+document.getElementById('btn-export-preview').addEventListener('click', () => {
+  app.previewExport();
+});
 
 // Detail close
 document

--- a/src/where_the_plow/static/app.js
+++ b/src/where_the_plow/static/app.js
@@ -1078,6 +1078,14 @@ class PlowApp {
       animFrame: null,
       lastRenderTime: 0,
     };
+
+    // Recording
+    this.recording = {
+      active: false,
+      cancelled: false,
+      output: null,
+      videoSource: null,
+    };
   }
 
   /* ── Sources ─────────────────────────────────────── */
@@ -1899,6 +1907,151 @@ class PlowApp {
 
     return `${window.location.origin}/?${params.toString()}`;
   }
+
+  /* ── Recording ──────────────────────────────────── */
+
+  async startRecording() {
+    if (!window.Mediabunny) {
+      alert('Mediabunny not loaded yet. Please wait a moment and try again.');
+      return;
+    }
+    if (!this.coverageData || !this.deckTrips) {
+      alert('Load a preview first before recording.');
+      return;
+    }
+
+    const { Output, Mp4OutputFormat, BufferTarget, CanvasSource } = window.Mediabunny;
+
+    const mapCanvas = this.map.map.getCanvas();
+    const width = mapCanvas.width;
+    const height = mapCanvas.height;
+
+    // Create compositing canvas
+    const composite = document.createElement('canvas');
+    composite.width = width;
+    composite.height = height;
+    const ctx = composite.getContext('2d');
+
+    const videoSource = new CanvasSource(composite, {
+      codec: 'avc',
+      bitrate: 4_000_000,
+    });
+
+    const output = new Output({
+      format: new Mp4OutputFormat(),
+      target: new BufferTarget(),
+    });
+    output.addVideoTrack(videoSource, { frameRate: 30 });
+
+    this.recording = { active: true, cancelled: false, output, videoSource };
+
+    // UI
+    const progressEl = document.getElementById('export-progress');
+    const progressFill = document.getElementById('export-progress-fill');
+    const progressText = document.getElementById('export-progress-text');
+    const actionsEl = document.getElementById('export-actions');
+    progressEl.style.display = 'flex';
+    actionsEl.style.display = 'none';
+    this.lockPlaybackUI();
+
+    await output.start();
+
+    const fps = 30;
+    const durationSec = parseInt(document.getElementById('export-speed').value);
+    const totalFrames = fps * durationSec;
+    const sinceMs = this.coverageSince.getTime();
+    const untilMs = this.coverageUntil.getTime();
+    const rangeMs = untilMs - sinceMs;
+
+    try {
+      for (let i = 0; i < totalFrames; i++) {
+        if (this.recording.cancelled) break;
+
+        const progress = i / totalFrames;
+        const currentTimeMs = sinceMs + progress * rangeMs;
+
+        // Update slider to match
+        const sliderVal = progress * 1000;
+        timeSliderEl.noUiSlider.set([0, sliderVal]);
+
+        // Render coverage at this time
+        this.renderCoverage(0, sliderVal);
+
+        // Wait a frame for WebGL to paint
+        await new Promise(r => requestAnimationFrame(r));
+        // Additional wait for deck.gl async rendering
+        await new Promise(r => setTimeout(r, 50));
+
+        // Composite: map + overlay
+        ctx.drawImage(mapCanvas, 0, 0);
+        this._drawRecordingOverlay(ctx, width, height, new Date(currentTimeMs));
+
+        // Feed frame to encoder
+        const timestamp = i / fps;
+        const duration = 1 / fps;
+        videoSource.add(timestamp, duration);
+
+        // Update progress
+        const pct = Math.round(progress * 100);
+        progressFill.style.width = pct + '%';
+        progressText.textContent = `Encoding: ${pct}%`;
+      }
+
+      if (!this.recording.cancelled) {
+        await output.finalize();
+
+        // Download
+        const blob = new Blob([output.target.buffer], { type: 'video/mp4' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'plow-coverage.mp4';
+        a.click();
+        URL.revokeObjectURL(url);
+      } else {
+        await output.cancel();
+      }
+    } catch (err) {
+      console.error('Recording failed:', err);
+      try { await output.cancel(); } catch (_) {}
+      alert('Recording failed: ' + err.message);
+    }
+
+    // Restore UI
+    this.recording.active = false;
+    progressEl.style.display = 'none';
+    actionsEl.style.display = 'flex';
+    this.unlockPlaybackUI();
+  }
+
+  cancelRecording() {
+    this.recording.cancelled = true;
+  }
+
+  _drawRecordingOverlay(ctx, width, height, time) {
+    const fontSize = Math.max(14, Math.round(height / 40));
+    ctx.font = `${fontSize}px sans-serif`;
+    ctx.textBaseline = 'bottom';
+
+    // Timestamp — bottom left
+    const timeStr = time.toLocaleString(undefined, {
+      year: 'numeric', month: 'short', day: 'numeric',
+      hour: '2-digit', minute: '2-digit',
+    });
+    ctx.shadowColor = 'rgba(0,0,0,0.8)';
+    ctx.shadowBlur = 4;
+    ctx.fillStyle = '#fff';
+    ctx.textAlign = 'left';
+    ctx.fillText(timeStr, 12, height - 12);
+
+    // Branding — bottom right
+    ctx.textAlign = 'right';
+    ctx.fillText('plow.jackharrhy.dev', width - 12, height - 12);
+
+    // Reset shadow
+    ctx.shadowColor = 'transparent';
+    ctx.shadowBlur = 0;
+  }
 }
 
 /* ── App init & event wiring ───────────────────────── */
@@ -2046,6 +2199,14 @@ document.getElementById('btn-export-link').addEventListener('click', () => {
     btn.textContent = 'Copied!';
     setTimeout(() => { btn.textContent = 'Copy Link'; }, 2000);
   });
+});
+
+// Export recording
+document.getElementById('btn-export-record').addEventListener('click', () => {
+  app.startRecording();
+});
+document.getElementById('btn-export-cancel').addEventListener('click', () => {
+  app.cancelRecording();
 });
 
 // Detail close

--- a/src/where_the_plow/static/app.js
+++ b/src/where_the_plow/static/app.js
@@ -1803,6 +1803,10 @@ class PlowApp {
   /* ── Export mode ────────────────────────────────── */
 
   enterExportMode() {
+    if (window.innerWidth < 768) {
+      alert('Video export works best on desktop. Please use a larger screen.');
+      return;
+    }
     this.exportMode = true;
     this.map.initDraw();
     document.getElementById('export-panel').style.display = 'block';
@@ -1859,6 +1863,7 @@ class PlowApp {
     // Store bbox for the fetch
     this._exportBbox = bboxParam;
 
+    gtag('event', 'export_preview', { bbox: this._exportBbox });
     await this.loadCoverageForRange(since, until);
 
     // Fit map to drawn region
@@ -1882,6 +1887,7 @@ class PlowApp {
   }
 
   generateShareLink() {
+    gtag('event', 'export_share_link');
     const bbox = this.map.getDrawnBbox();
     const startDate = document.getElementById('export-date-start').value;
     const endDate = document.getElementById('export-date-end').value;
@@ -1953,7 +1959,9 @@ class PlowApp {
     progressEl.style.display = 'flex';
     actionsEl.style.display = 'none';
     this.lockPlaybackUI();
+    this.map.map.getContainer().style.pointerEvents = 'none';
 
+    gtag('event', 'export_record_start');
     await output.start();
 
     const fps = 30;
@@ -1999,6 +2007,7 @@ class PlowApp {
 
       if (!this.recording.cancelled) {
         await output.finalize();
+        gtag('event', 'export_record_complete', { duration_sec: durationSec, frames: totalFrames });
 
         // Download
         const blob = new Blob([output.target.buffer], { type: 'video/mp4' });
@@ -2021,6 +2030,7 @@ class PlowApp {
     this.recording.active = false;
     progressEl.style.display = 'none';
     actionsEl.style.display = 'flex';
+    this.map.map.getContainer().style.pointerEvents = '';
     this.unlockPlaybackUI();
   }
 

--- a/src/where_the_plow/static/app.js
+++ b/src/where_the_plow/static/app.js
@@ -1926,6 +1926,17 @@ class PlowApp {
       return;
     }
 
+    // Ensure bbox is available — derive from drawn polygon if needed
+    if (!this._exportBbox) {
+      const bbox = this.map.getDrawnBbox();
+      if (bbox) {
+        this._exportBbox = bbox.join(',');
+      } else {
+        alert('Draw a region first before recording.');
+        return;
+      }
+    }
+
     const { Output, Mp4OutputFormat, BufferTarget, CanvasSource } = window.Mediabunny;
 
     const mapCanvas = this.map.map.getCanvas();

--- a/src/where_the_plow/static/app.js
+++ b/src/where_the_plow/static/app.js
@@ -1018,6 +1018,22 @@ legendToggleBtn.addEventListener("click", () => {
   legendToggleBtn.classList.toggle("collapsed", collapsed);
 });
 
+/* ── Replay URL params ─────────────────────────────── */
+
+function parseReplayParams() {
+    const params = new URLSearchParams(window.location.search);
+    if (params.get('mode') !== 'replay') return null;
+    return {
+        since: params.get('since'),
+        until: params.get('until'),
+        speed: params.get('speed') || '30',
+        center: params.get('center'),
+        zoom: params.get('zoom'),
+        bbox: params.get('bbox'),
+        polygon: params.get('polygon'),
+    };
+}
+
 /* ── PlowApp class ─────────────────────────────────── */
 
 class PlowApp {
@@ -1856,6 +1872,33 @@ class PlowApp {
     const hasWebCodecs = typeof VideoEncoder !== 'undefined';
     document.getElementById('btn-export-record').disabled = !(ready && hasWebCodecs);
   }
+
+  generateShareLink() {
+    const bbox = this.map.getDrawnBbox();
+    const startDate = document.getElementById('export-date-start').value;
+    const endDate = document.getElementById('export-date-end').value;
+    const speed = document.getElementById('export-speed').value;
+    const center = this.map.map.getCenter();
+    const zoom = this.map.map.getZoom().toFixed(2);
+
+    const params = new URLSearchParams({
+      mode: 'replay',
+      since: startDate,
+      until: endDate,
+      speed: speed,
+      center: `${center.lat.toFixed(4)},${center.lng.toFixed(4)}`,
+      zoom: zoom,
+    });
+    if (bbox) {
+      params.set('bbox', bbox.map(v => v.toFixed(6)).join(','));
+    }
+    const polygon = this.map.getDrawnPolygon();
+    if (polygon) {
+      params.set('polygon', JSON.stringify(polygon.geometry.coordinates[0]));
+    }
+
+    return `${window.location.origin}/?${params.toString()}`;
+  }
 }
 
 /* ── App init & event wiring ───────────────────────── */
@@ -1995,6 +2038,16 @@ document.getElementById('btn-export-preview').addEventListener('click', () => {
   app.previewExport();
 });
 
+// Export share link
+document.getElementById('btn-export-link').addEventListener('click', () => {
+  const url = app.generateShareLink();
+  navigator.clipboard.writeText(url).then(() => {
+    const btn = document.getElementById('btn-export-link');
+    btn.textContent = 'Copied!';
+    setTimeout(() => { btn.textContent = 'Copy Link'; }, 2000);
+  });
+});
+
 // Detail close
 document
   .getElementById("detail-close")
@@ -2053,4 +2106,61 @@ plowMap.on("load", async () => {
   });
 
   app.startAutoRefresh();
+
+  // Auto-load replay mode from URL params
+  const replayParams = parseReplayParams();
+  if (replayParams) {
+    // Skip welcome modal
+    document.getElementById('welcome-overlay').style.display = 'none';
+
+    // Switch to coverage mode
+    await app.switchMode('coverage');
+
+    // Set camera
+    if (replayParams.center && replayParams.zoom) {
+      const [lat, lng] = replayParams.center.split(',').map(Number);
+      plowMap.map.jumpTo({ center: [lng, lat], zoom: parseFloat(replayParams.zoom) });
+    }
+
+    // Load coverage with bbox
+    if (replayParams.since && replayParams.until) {
+      const since = new Date(replayParams.since + 'T00:00:00');
+      const until = new Date(replayParams.until + 'T23:59:59');
+      if (replayParams.bbox) {
+        app._exportBbox = replayParams.bbox;
+      }
+      await app.loadCoverageForRange(since, until);
+
+      // Draw polygon outline if provided
+      if (replayParams.polygon) {
+        try {
+          const coords = JSON.parse(replayParams.polygon);
+          plowMap.map.addSource('replay-polygon', {
+            type: 'geojson',
+            data: {
+              type: 'Feature',
+              geometry: { type: 'Polygon', coordinates: [coords] },
+            },
+          });
+          plowMap.map.addLayer({
+            id: 'replay-polygon-outline',
+            type: 'line',
+            source: 'replay-polygon',
+            paint: {
+              'line-color': '#fff',
+              'line-width': 2,
+              'line-dasharray': [3, 2],
+              'line-opacity': 0.6,
+            },
+          });
+        } catch (e) {
+          console.warn('Failed to parse replay polygon:', e);
+        }
+      }
+
+      // Set playback speed and auto-start
+      playbackSpeedSelect.value = replayParams.speed;
+      app.startPlayback();
+    }
+  }
 });

--- a/src/where_the_plow/static/app.js
+++ b/src/where_the_plow/static/app.js
@@ -1936,7 +1936,7 @@ class PlowApp {
     const composite = document.createElement('canvas');
     composite.width = width;
     composite.height = height;
-    const ctx = composite.getContext('2d');
+    const ctx = composite.getContext('2d', { willReadFrequently: true });
 
     const videoSource = new CanvasSource(composite, {
       codec: 'avc',
@@ -1985,10 +1985,11 @@ class PlowApp {
         // Render coverage at this time
         this.renderCoverage(0, sliderVal);
 
-        // Wait a frame for WebGL to paint
+        // Force MapLibre to render and wait for the frame to actually paint
+        this.map.map.triggerRepaint();
+        await new Promise(r => this.map.map.once('render', r));
+        // Extra rAF to ensure the WebGL draw commands are flushed
         await new Promise(r => requestAnimationFrame(r));
-        // Additional wait for deck.gl async rendering
-        await new Promise(r => setTimeout(r, 50));
 
         // Composite: map + overlay
         ctx.drawImage(mapCanvas, 0, 0);

--- a/src/where_the_plow/static/app.js
+++ b/src/where_the_plow/static/app.js
@@ -1997,7 +1997,7 @@ class PlowApp {
         // Feed frame to encoder
         const timestamp = i / fps;
         const duration = 1 / fps;
-        videoSource.add(timestamp, duration);
+        await videoSource.add(timestamp, duration);
 
         // Update progress
         const pct = Math.round(progress * 100);
@@ -2225,7 +2225,7 @@ document
 
 plowMap.on("load", async () => {
   // Initialize deck.gl overlay for coverage rendering
-  plowMap.deckOverlay = new deck.MapboxOverlay({ layers: [] });
+  plowMap.deckOverlay = new deck.MapboxOverlay({ interleaved: true, layers: [] });
   plowMap.map.addControl(plowMap.deckOverlay);
 
   // Listen for Mapbox Draw events

--- a/src/where_the_plow/static/app.js
+++ b/src/where_the_plow/static/app.js
@@ -630,6 +630,42 @@ class PlowMap {
     this.coverageAbort = new AbortController();
     return this.coverageAbort.signal;
   }
+
+  /* ── Draw (Mapbox Draw) ────────────────────────── */
+
+  initDraw() {
+    this.draw = new MapboxDraw({
+      displayControlsDefault: false,
+      controls: {},
+      defaultMode: 'simple_select',
+    });
+    this.map.addControl(this.draw, 'top-left');
+  }
+
+  getDrawnPolygon() {
+    if (!this.draw) return null;
+    const data = this.draw.getAll();
+    if (!data || data.features.length === 0) return null;
+    return data.features[0];
+  }
+
+  clearDraw() {
+    if (this.draw) this.draw.deleteAll();
+  }
+
+  getDrawnBbox() {
+    const feature = this.getDrawnPolygon();
+    if (!feature) return null;
+    const coords = feature.geometry.coordinates[0];
+    let west = Infinity, south = Infinity, east = -Infinity, north = -Infinity;
+    for (const [lng, lat] of coords) {
+      if (lng < west) west = lng;
+      if (lng > east) east = lng;
+      if (lat < south) south = lat;
+      if (lat > north) north = lat;
+    }
+    return [west, south, east, north];
+  }
 }
 
 /* ── Map view persistence ──────────────────────────── */
@@ -1010,6 +1046,10 @@ class PlowApp {
     this.coverageUntil = null;
     this.coveragePreset = "24";
     this.coverageView = "lines";
+
+    // Export
+    this.exportMode = false;
+    this.exportPolygon = null;
 
     // Playback
     this.playback = {
@@ -1408,6 +1448,8 @@ class PlowApp {
     document.getElementById("vehicle-count").style.display = "";
     document.getElementById("db-size").style.display = "none";
     vehicleHint.style.display = "";
+    document.getElementById('btn-export-mode').style.display = 'none';
+    if (this.exportMode) this.exitExportMode();
     showLegend("vehicles");
     this.startAutoRefresh();
   }
@@ -1425,6 +1467,7 @@ class PlowApp {
     document.getElementById("db-size").style.display = "";
     vehicleHint.style.display = "none";
     coveragePanelEl.style.display = "block";
+    document.getElementById('btn-export-mode').style.display = 'block';
     btnPlay.disabled = true;
 
     this.coveragePreset = "24";
@@ -1731,6 +1774,65 @@ class PlowApp {
       { type: "FeatureCollection", features: buildTrailSegments(features) },
     );
   }
+
+  /* ── Export mode ────────────────────────────────── */
+
+  enterExportMode() {
+    this.exportMode = true;
+    this.map.initDraw();
+    document.getElementById('export-panel').style.display = 'block';
+    document.getElementById('btn-export-mode').textContent = 'Exit Export';
+
+    // Set date picker bounds
+    const startInput = document.getElementById('export-date-start');
+    const endInput = document.getElementById('export-date-end');
+    if (coverageDateInput.min) startInput.min = coverageDateInput.min;
+    if (coverageDateInput.max) endInput.max = coverageDateInput.max;
+    startInput.max = coverageDateInput.max;
+    endInput.min = startInput.min;
+
+    // Default: last 3 days
+    const now = new Date();
+    const threeDaysAgo = new Date(now.getTime() - 3 * 24 * 60 * 60 * 1000);
+    endInput.value = now.toISOString().slice(0, 10);
+    startInput.value = threeDaysAgo.toISOString().slice(0, 10);
+
+    // Check WebCodecs support
+    if (typeof VideoEncoder === 'undefined') {
+      document.getElementById('export-unsupported').style.display = 'block';
+      document.getElementById('btn-export-record').disabled = true;
+    }
+
+    this.updateExportButtons();
+  }
+
+  exitExportMode() {
+    this.exportMode = false;
+    this.map.clearDraw();
+    if (this.map.draw) {
+      this.map.map.removeControl(this.map.draw);
+      this.map.draw = null;
+    }
+    document.getElementById('export-panel').style.display = 'none';
+    document.getElementById('btn-export-mode').textContent = 'Export Region';
+    document.getElementById('export-unsupported').style.display = 'none';
+    this.exportPolygon = null;
+  }
+
+  updateExportButtons() {
+    const hasPolygon = this.map.getDrawnPolygon() !== null;
+    const startDate = document.getElementById('export-date-start').value;
+    const endDate = document.getElementById('export-date-end').value;
+    const hasDates = startDate && endDate && startDate <= endDate;
+    const ready = hasPolygon && hasDates;
+
+    document.getElementById('btn-draw-clear').disabled = !hasPolygon;
+    document.getElementById('btn-export-preview').disabled = !ready;
+    document.getElementById('btn-export-link').disabled = !ready;
+
+    const hasWebCodecs = typeof VideoEncoder !== 'undefined';
+    document.getElementById('btn-export-record').disabled = !(ready && hasWebCodecs);
+  }
 }
 
 /* ── App init & event wiring ───────────────────────── */
@@ -1840,6 +1942,31 @@ playbackFollowSelect.addEventListener("change", () => {
   app.playback.followVehicleId = playbackFollowSelect.value || null;
 });
 
+// Export mode toggle
+document.getElementById('btn-export-mode').addEventListener('click', () => {
+  if (app.exportMode) {
+    app.exitExportMode();
+  } else {
+    app.enterExportMode();
+  }
+});
+
+// Draw buttons
+document.getElementById('btn-draw-polygon').addEventListener('click', () => {
+  if (app.map.draw) app.map.draw.changeMode('draw_polygon');
+});
+document.getElementById('btn-draw-rectangle').addEventListener('click', () => {
+  if (app.map.draw) app.map.draw.changeMode('draw_polygon');
+});
+document.getElementById('btn-draw-clear').addEventListener('click', () => {
+  app.map.clearDraw();
+  app.updateExportButtons();
+});
+
+// Export date inputs update button state
+document.getElementById('export-date-start').addEventListener('change', () => app.updateExportButtons());
+document.getElementById('export-date-end').addEventListener('change', () => app.updateExportButtons());
+
 // Detail close
 document
   .getElementById("detail-close")
@@ -1851,6 +1978,20 @@ plowMap.on("load", async () => {
   // Initialize deck.gl overlay for coverage rendering
   plowMap.deckOverlay = new deck.MapboxOverlay({ layers: [] });
   plowMap.map.addControl(plowMap.deckOverlay);
+
+  // Listen for Mapbox Draw events
+  plowMap.on('draw.create', () => {
+    // Only allow one polygon at a time
+    const data = plowMap.draw?.getAll();
+    if (data && data.features.length > 1) {
+      const latest = data.features[data.features.length - 1];
+      plowMap.draw.deleteAll();
+      plowMap.draw.add(latest);
+    }
+    app.updateExportButtons();
+  });
+  plowMap.on('draw.update', () => app.updateExportButtons());
+  plowMap.on('draw.delete', () => app.updateExportButtons());
 
   await app.loadSources();
 

--- a/src/where_the_plow/static/app.js
+++ b/src/where_the_plow/static/app.js
@@ -699,6 +699,7 @@ const plowMap = new PlowMap("map", {
   style: "https://tiles.openfreemap.org/styles/liberty",
   center: savedView ? savedView.center : [-52.71, 47.56],
   zoom: savedView ? savedView.zoom : 12,
+  preserveDrawingBuffer: true,
 });
 
 const geolocate = new maplibregl.GeolocateControl({
@@ -1065,7 +1066,7 @@ class PlowApp {
 
     // Export
     this.exportMode = false;
-    this.exportPolygon = null;
+    this._exportBbox = null;
 
     // Playback
     this.playback = {
@@ -1846,7 +1847,6 @@ class PlowApp {
     document.getElementById('export-panel').style.display = 'none';
     document.getElementById('btn-export-mode').textContent = 'Export Region';
     document.getElementById('export-unsupported').style.display = 'none';
-    this.exportPolygon = null;
   }
 
   async previewExport() {
@@ -2184,9 +2184,6 @@ document.getElementById('btn-export-mode').addEventListener('click', () => {
 document.getElementById('btn-draw-polygon').addEventListener('click', () => {
   if (app.map.draw) app.map.draw.changeMode('draw_polygon');
 });
-document.getElementById('btn-draw-rectangle').addEventListener('click', () => {
-  if (app.map.draw) app.map.draw.changeMode('draw_polygon');
-});
 document.getElementById('btn-draw-clear').addEventListener('click', () => {
   app.map.clearDraw();
   app.updateExportButtons();
@@ -2303,9 +2300,12 @@ plowMap.on("load", async () => {
       await app.loadCoverageForRange(since, until);
 
       // Draw polygon outline if provided
-      if (replayParams.polygon) {
+      if (replayParams.polygon && replayParams.polygon.length < 10000) {
         try {
           const coords = JSON.parse(replayParams.polygon);
+          if (!Array.isArray(coords) || !coords.every(c => Array.isArray(c) && c.length >= 2)) {
+            throw new Error('Invalid polygon coordinates');
+          }
           plowMap.map.addSource('replay-polygon', {
             type: 'geojson',
             data: {

--- a/src/where_the_plow/static/index.html
+++ b/src/where_the_plow/static/index.html
@@ -75,7 +75,7 @@
         <script src="https://unpkg.com/nouislider@15/dist/nouislider.min.js"></script>
         <script src="https://unpkg.com/@mapbox/mapbox-gl-draw@1/dist/mapbox-gl-draw.js"></script>
         <script type="module" id="mediabunny-loader">
-            import { Output, Mp4OutputFormat, BufferTarget, CanvasSource } from 'https://esm.sh/mediabunny@0';
+            import { Output, Mp4OutputFormat, BufferTarget, CanvasSource } from 'https://esm.sh/mediabunny@1';
             window.Mediabunny = { Output, Mp4OutputFormat, BufferTarget, CanvasSource };
             window.dispatchEvent(new Event('mediabunny-ready'));
         </script>

--- a/src/where_the_plow/static/index.html
+++ b/src/where_the_plow/static/index.html
@@ -68,10 +68,17 @@
             rel="stylesheet"
             href="https://unpkg.com/nouislider@15/dist/nouislider.min.css"
         />
+        <link rel="stylesheet" href="https://unpkg.com/@mapbox/mapbox-gl-draw@1/dist/mapbox-gl-draw.css" />
         <link rel="stylesheet" href="/static/style.css" />
         <script src="https://unpkg.com/maplibre-gl@5/dist/maplibre-gl.js"></script>
         <script src="https://unpkg.com/deck.gl@^9.0.0/dist.min.js"></script>
         <script src="https://unpkg.com/nouislider@15/dist/nouislider.min.js"></script>
+        <script src="https://unpkg.com/@mapbox/mapbox-gl-draw@1/dist/mapbox-gl-draw.js"></script>
+        <script type="module" id="mediabunny-loader">
+            import { Output, Mp4OutputFormat, BufferTarget, CanvasSource } from 'https://esm.sh/mediabunny@0';
+            window.Mediabunny = { Output, Mp4OutputFormat, BufferTarget, CanvasSource };
+            window.dispatchEvent(new Event('mediabunny-ready'));
+        </script>
     </head>
     <body>
         <div id="map"></div>
@@ -131,6 +138,7 @@
                     <button id="btn-lines" class="active">Lines</button>
                     <button id="btn-heatmap">Heatmap</button>
                 </div>
+                <button id="btn-export-mode" class="export-toggle-btn" style="display: none">Export Region</button>
                 <div class="coverage-hint">
                     Drag the handles to narrow the visible time range
                 </div>
@@ -158,6 +166,45 @@
                     </div>
                 </div>
                 <div id="coverage-loading">Loading coverage data...</div>
+                <div id="export-panel" style="display: none">
+                    <div class="coverage-hint export-section-title">
+                        Export Region Video
+                    </div>
+                    <div id="export-draw-controls" class="export-row">
+                        <button id="btn-draw-polygon" title="Draw polygon">Polygon</button>
+                        <button id="btn-draw-rectangle" title="Draw rectangle">Rectangle</button>
+                        <button id="btn-draw-clear" title="Clear drawing" disabled>Clear</button>
+                    </div>
+                    <div id="export-date-range" class="export-row">
+                        <label>From</label>
+                        <input type="date" id="export-date-start" />
+                        <label>To</label>
+                        <input type="date" id="export-date-end" />
+                    </div>
+                    <div id="export-speed-row" class="export-row">
+                        <label>Video duration</label>
+                        <select id="export-speed">
+                            <option value="15">15s</option>
+                            <option value="30" selected>30s</option>
+                            <option value="60">1m</option>
+                        </select>
+                    </div>
+                    <div id="export-actions" class="export-row">
+                        <button id="btn-export-preview" disabled>Preview</button>
+                        <button id="btn-export-record" disabled>Export MP4</button>
+                        <button id="btn-export-link" disabled>Copy Link</button>
+                    </div>
+                    <div id="export-progress" style="display: none">
+                        <div id="export-progress-bar">
+                            <div id="export-progress-fill"></div>
+                        </div>
+                        <span id="export-progress-text">Encoding...</span>
+                        <button id="btn-export-cancel">Cancel</button>
+                    </div>
+                    <div id="export-unsupported" style="display: none">
+                        Video export requires a Chromium-based browser (Chrome, Edge) or Safari 16.4+.
+                    </div>
+                </div>
             </div>
             <div id="legend">
                 <div id="legend-header">

--- a/src/where_the_plow/static/index.html
+++ b/src/where_the_plow/static/index.html
@@ -171,8 +171,7 @@
                         Export Region Video
                     </div>
                     <div id="export-draw-controls" class="export-row">
-                        <button id="btn-draw-polygon" title="Draw polygon">Polygon</button>
-                        <button id="btn-draw-rectangle" title="Draw rectangle">Rectangle</button>
+                        <button id="btn-draw-polygon" title="Draw polygon on map">Draw Region</button>
                         <button id="btn-draw-clear" title="Clear drawing" disabled>Clear</button>
                     </div>
                     <div id="export-date-range" class="export-row">

--- a/src/where_the_plow/static/style.css
+++ b/src/where_the_plow/static/style.css
@@ -368,6 +368,152 @@ body.controls-left .maplibregl-ctrl-bottom-right .maplibregl-ctrl {
     display: none;
 }
 
+/* ── Export panel ───────────────────────────────────── */
+
+.export-toggle-btn {
+    width: 100%;
+    padding: 6px 10px;
+    margin: 6px 0;
+    background: var(--color-accent);
+    color: #fff;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.8rem;
+}
+.export-toggle-btn:hover {
+    opacity: 0.9;
+}
+
+#export-panel {
+    margin-top: 8px;
+    padding-top: 8px;
+    border-top: var(--border-subtle);
+}
+
+.export-section-title {
+    font-weight: 600;
+    margin-bottom: 6px;
+}
+
+.export-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-bottom: 6px;
+    flex-wrap: wrap;
+}
+
+.export-row label {
+    font-size: 0.75rem;
+    color: var(--color-text-secondary);
+    white-space: nowrap;
+}
+
+.export-row input[type="date"] {
+    flex: 1;
+    min-width: 0;
+    background: var(--color-input-bg);
+    color: var(--color-text);
+    border: var(--border-subtle);
+    border-radius: 3px;
+    padding: 3px 4px;
+    font-size: 0.75rem;
+}
+
+.export-row select {
+    flex: 1;
+    background: var(--color-input-bg);
+    color: var(--color-text);
+    border: var(--border-subtle);
+    border-radius: 3px;
+    padding: 3px 4px;
+    font-size: 0.75rem;
+}
+
+#export-draw-controls button {
+    flex: 1;
+    padding: 4px 8px;
+    background: var(--color-input-bg);
+    color: var(--color-text);
+    border: var(--border-subtle);
+    border-radius: 3px;
+    cursor: pointer;
+    font-size: 0.75rem;
+}
+#export-draw-controls button:hover:not(:disabled) {
+    background: var(--color-hover-bg);
+}
+#export-draw-controls button:disabled {
+    opacity: 0.4;
+    cursor: default;
+}
+
+#export-actions button {
+    flex: 1;
+    padding: 5px 8px;
+    border: var(--border-subtle);
+    border-radius: 3px;
+    cursor: pointer;
+    font-size: 0.75rem;
+    background: var(--color-input-bg);
+    color: var(--color-text);
+}
+#export-actions button:disabled {
+    opacity: 0.4;
+    cursor: default;
+}
+#btn-export-record {
+    background: var(--color-accent);
+    color: #fff;
+    border-color: var(--color-accent);
+}
+#btn-export-record:disabled {
+    background: var(--color-input-bg);
+    color: var(--color-text);
+    border: var(--border-subtle);
+}
+
+#export-progress {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: 6px;
+}
+#export-progress-bar {
+    flex: 1;
+    height: 6px;
+    background: var(--color-input-bg);
+    border-radius: 3px;
+    overflow: hidden;
+}
+#export-progress-fill {
+    height: 100%;
+    width: 0%;
+    background: var(--color-accent);
+    transition: width 0.2s;
+}
+#export-progress-text {
+    font-size: 0.7rem;
+    color: var(--color-text-secondary);
+    white-space: nowrap;
+}
+#btn-export-cancel {
+    padding: 2px 8px;
+    background: transparent;
+    color: var(--color-text-muted);
+    border: var(--border-subtle);
+    border-radius: 3px;
+    cursor: pointer;
+    font-size: 0.7rem;
+}
+
+#export-unsupported {
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+    padding: 4px 0;
+}
+
 /* ── Ko-fi widget ──────────────────────────────────── */
 
 #kofi-container {

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1037,6 +1037,115 @@ def test_get_latest_positions_with_source_filter():
     os.unlink(path)
 
 
+def test_get_coverage_trails_bbox_filter():
+    """Bbox filter should only return positions within the bounding box."""
+    db, path = make_db()
+    now = datetime.now(timezone.utc)
+    ts1 = datetime(2026, 2, 19, 12, 0, 0, tzinfo=timezone.utc)
+    ts2 = datetime(2026, 2, 19, 12, 0, 30, tzinfo=timezone.utc)
+    ts3 = datetime(2026, 2, 19, 12, 1, 0, tzinfo=timezone.utc)
+
+    db.upsert_vehicles(
+        [
+            {
+                "vehicle_id": "v1",
+                "description": "Plow 1",
+                "vehicle_type": "SA PLOW TRUCK",
+            },
+            {"vehicle_id": "v2", "description": "Plow 2", "vehicle_type": "LOADER"},
+        ],
+        now,
+    )
+    # v1 in downtown area (-52.73, 47.56) to (-52.75, 47.58)
+    # v2 far away at (-53.00, 47.30)
+    db.insert_positions(
+        [
+            {
+                "vehicle_id": "v1",
+                "timestamp": ts1,
+                "longitude": -52.73,
+                "latitude": 47.56,
+                "bearing": 0,
+                "speed": 10.0,
+                "is_driving": "maybe",
+            },
+            {
+                "vehicle_id": "v1",
+                "timestamp": ts2,
+                "longitude": -52.74,
+                "latitude": 47.57,
+                "bearing": 90,
+                "speed": 15.0,
+                "is_driving": "maybe",
+            },
+            {
+                "vehicle_id": "v1",
+                "timestamp": ts3,
+                "longitude": -52.75,
+                "latitude": 47.58,
+                "bearing": 180,
+                "speed": 20.0,
+                "is_driving": "maybe",
+            },
+            {
+                "vehicle_id": "v2",
+                "timestamp": ts1,
+                "longitude": -53.00,
+                "latitude": 47.30,
+                "bearing": 0,
+                "speed": 5.0,
+                "is_driving": "maybe",
+            },
+            {
+                "vehicle_id": "v2",
+                "timestamp": ts2,
+                "longitude": -53.01,
+                "latitude": 47.31,
+                "bearing": 0,
+                "speed": 5.0,
+                "is_driving": "maybe",
+            },
+            {
+                "vehicle_id": "v2",
+                "timestamp": ts3,
+                "longitude": -53.02,
+                "latitude": 47.32,
+                "bearing": 0,
+                "speed": 5.0,
+                "is_driving": "maybe",
+            },
+        ],
+        now,
+    )
+
+    # Bbox around downtown — should include v1, exclude v2
+    trails = db.get_coverage_trails(
+        since=ts1, until=ts3, bbox=(-52.80, 47.50, -52.70, 47.60)
+    )
+    assert len(trails) == 1
+    assert trails[0]["vehicle_id"] == "v1"
+
+    # Bbox around v2's area — should include v2, exclude v1
+    trails = db.get_coverage_trails(
+        since=ts1, until=ts3, bbox=(-53.10, 47.25, -52.95, 47.35)
+    )
+    assert len(trails) == 1
+    assert trails[0]["vehicle_id"] == "v2"
+
+    # Bbox that includes neither
+    trails = db.get_coverage_trails(
+        since=ts1, until=ts3, bbox=(-50.00, 48.00, -49.00, 49.00)
+    )
+    assert len(trails) == 0
+
+    # No bbox — returns both vehicles
+    trails = db.get_coverage_trails(since=ts1, until=ts3)
+    assert len(trails) == 2
+
+    db.close()
+    os.unlink(path)
+
+
 def test_get_latest_positions_with_trails_no_gap():
     """When all positions are within the gap threshold, the full trail is returned."""
     db, path = make_db()

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,7 +1,7 @@
 # tests/test_db.py
 import os
 import tempfile
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 from where_the_plow.db import Database
 
@@ -1155,8 +1155,6 @@ def test_get_latest_positions_with_trails_no_gap():
         [{"vehicle_id": "v1", "description": "Plow 1", "vehicle_type": "LOADER"}], now
     )
     # 4 positions all 30s apart (well within 120s threshold)
-    from datetime import timedelta
-
     base = datetime(2026, 2, 19, 12, 0, 0, tzinfo=timezone.utc)
     positions = [
         {
@@ -1179,3 +1177,106 @@ def test_get_latest_positions_with_trails_no_gap():
 
     db.close()
     os.unlink(path)
+
+
+def test_get_activity_segments():
+    db, path = make_db()
+    try:
+        now = datetime(2026, 2, 19, 12, 0, 0, tzinfo=timezone.utc)
+        db.upsert_vehicles(
+            [
+                {
+                    "vehicle_id": "v1",
+                    "description": "Plow 1",
+                    "vehicle_type": "SA PLOW TRUCK",
+                },
+            ],
+            now,
+        )
+        # Session 1: 3 positions at 30s intervals starting at now
+        # Gap: 20 minutes (> 15min threshold)
+        # Session 2: 2 positions at 30s intervals starting at now+20min
+        positions = [
+            {
+                "vehicle_id": "v1",
+                "timestamp": now,
+                "longitude": -52.73,
+                "latitude": 47.56,
+                "bearing": 0,
+                "speed": 10.0,
+                "is_driving": "maybe",
+            },
+            {
+                "vehicle_id": "v1",
+                "timestamp": now + timedelta(seconds=30),
+                "longitude": -52.74,
+                "latitude": 47.57,
+                "bearing": 0,
+                "speed": 10.0,
+                "is_driving": "maybe",
+            },
+            {
+                "vehicle_id": "v1",
+                "timestamp": now + timedelta(seconds=60),
+                "longitude": -52.75,
+                "latitude": 47.58,
+                "bearing": 0,
+                "speed": 10.0,
+                "is_driving": "maybe",
+            },
+            # 20 minute gap
+            {
+                "vehicle_id": "v1",
+                "timestamp": now + timedelta(minutes=20),
+                "longitude": -52.73,
+                "latitude": 47.56,
+                "bearing": 0,
+                "speed": 10.0,
+                "is_driving": "maybe",
+            },
+            {
+                "vehicle_id": "v1",
+                "timestamp": now + timedelta(minutes=20, seconds=30),
+                "longitude": -52.74,
+                "latitude": 47.57,
+                "bearing": 0,
+                "speed": 10.0,
+                "is_driving": "maybe",
+            },
+        ]
+        db.insert_positions(positions, now)
+
+        since = now - timedelta(minutes=5)
+        until = now + timedelta(minutes=25)
+        bbox = (-52.80, 47.50, -52.70, 47.60)
+
+        segments = db.get_activity_segments(
+            since, until, bbox, gap_threshold_minutes=15
+        )
+
+        # Expect: leading gap, session 1, gap, session 2, trailing gap
+        assert len(segments) == 5
+        assert segments[0]["type"] == "gap"  # since → first position
+        assert segments[1]["type"] == "active"  # session 1
+        assert segments[2]["type"] == "gap"  # between sessions
+        assert segments[3]["type"] == "active"  # session 2
+        assert segments[4]["type"] == "gap"  # last position → until
+
+        # Active segments should have correct boundaries
+        assert segments[1]["start"] == now.isoformat()
+        assert segments[1]["end"] == (now + timedelta(seconds=60)).isoformat()
+        assert segments[3]["start"] == (now + timedelta(minutes=20)).isoformat()
+        assert (
+            segments[3]["end"] == (now + timedelta(minutes=20, seconds=30)).isoformat()
+        )
+
+        # No activity → single gap segment covering entire range
+        far_bbox = (-50.0, 48.0, -49.0, 49.0)
+        segments_empty = db.get_activity_segments(
+            since, until, far_bbox, gap_threshold_minutes=15
+        )
+        assert len(segments_empty) == 1
+        assert segments_empty[0]["type"] == "gap"
+    finally:
+        db.close()
+        os.unlink(path)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -343,6 +343,50 @@ def test_get_coverage_with_source_filter(test_client):
     assert len(data["features"]) == 0
 
 
+def test_get_coverage_with_bbox_filter(test_client):
+    # v1 positions are around (-52.73 to -52.75, 47.56 to 47.58)
+    # v2 position is at (-52.80, 47.50) — only 1 position so no trail
+    # Bbox around v1 — should return v1's trail
+    resp = test_client.get(
+        "/coverage?since=2026-02-19T00:00:00Z&until=2026-02-20T00:00:00Z"
+        "&bbox=-52.80,47.50,-52.70,47.60"
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["type"] == "FeatureCollection"
+    assert len(data["features"]) == 1
+    assert data["features"][0]["properties"]["vehicle_id"] == "v1"
+
+    # Bbox far away — should return empty
+    resp = test_client.get(
+        "/coverage?since=2026-02-19T00:00:00Z&until=2026-02-20T00:00:00Z"
+        "&bbox=-50.00,48.00,-49.00,49.00"
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["features"]) == 0
+
+
+def test_get_coverage_with_invalid_bbox(test_client):
+    # Not enough values
+    resp = test_client.get(
+        "/coverage?since=2026-02-19T00:00:00Z&until=2026-02-20T00:00:00Z&bbox=1,2,3"
+    )
+    assert resp.status_code == 422
+
+    # Non-numeric
+    resp = test_client.get(
+        "/coverage?since=2026-02-19T00:00:00Z&until=2026-02-20T00:00:00Z&bbox=bad"
+    )
+    assert resp.status_code == 422
+
+    # Too many values
+    resp = test_client.get(
+        "/coverage?since=2026-02-19T00:00:00Z&until=2026-02-20T00:00:00Z&bbox=1,2,3,4,5"
+    )
+    assert resp.status_code == 422
+
+
 def test_openapi_spec(test_client):
     resp = test_client.get("/openapi.json")
     assert resp.status_code == 200

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -387,6 +387,36 @@ def test_get_coverage_with_invalid_bbox(test_client):
     assert resp.status_code == 422
 
 
+def test_get_coverage_segments(test_client):
+    """Segments endpoint returns activity/gap segments."""
+    client = test_client
+    resp = client.get(
+        "/coverage/segments",
+        params={
+            "since": "2026-02-19T11:00:00Z",
+            "until": "2026-02-19T13:00:00Z",
+            "bbox": "-52.80,47.50,-52.70,47.60",
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "segments" in data
+    assert "gap_threshold_minutes" in data
+    types = [s["type"] for s in data["segments"]]
+    assert "active" in types
+    assert "gap" in types
+
+
+def test_get_coverage_segments_requires_bbox(test_client):
+    """Segments endpoint requires bbox parameter."""
+    client = test_client
+    resp = client.get(
+        "/coverage/segments",
+        params={"since": "2026-02-19T11:00:00Z", "until": "2026-02-19T13:00:00Z"},
+    )
+    assert resp.status_code == 422
+
+
 def test_openapi_spec(test_client):
     resp = test_client.get("/openapi.json")
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary

Implements #29 — select a region on the map, preview plow activity over a multi-day date range, export an MP4 video, or share a replay link.

- **Backend**: Added `bbox` spatial filter parameter to `/coverage` endpoint using DuckDB `ST_Intersects` + `ST_MakeEnvelope`. Includes coordinate-order validation and cache key integration.
- **Frontend**: Mapbox Draw for polygon region selection, export UI panel with date range pickers and speed controls, preview using existing deck.gl TripsLayer playback, MP4 video recording via Mediabunny (WebCodecs-based, ~17kB vs FFmpeg WASM's ~25MB), shareable stateless replay links encoded in URL params.
- **Video overlay**: Timestamp + `plow.jackharrhy.dev` branding composited onto each frame.
- **Browser support**: Video export requires Chrome/Edge/Safari 16.4+ (WebCodecs). Firefox users can still use shareable replay links. Mobile shows a desktop-only warning.

## Key technical decisions

- **Mediabunny over FFmpeg WASM**: 67x faster encoding, 1000x smaller bundle, `CanvasSource` API purpose-built for this use case
- **Stepped playback for recording**: Frames captured at target FPS regardless of machine speed, not real-time
- **`preserveDrawingBuffer: true`** on MapLibre map to enable canvas capture (minor perf cost)
- **Stateless shareable links**: Everything encoded in URL params, no server state needed

## Test plan

- [x] `uv run pytest -v` — 106 tests pass (2 new DB + 3 new route tests for bbox)
- [ ] Manual: draw polygon, set multi-day range, preview playback
- [ ] Manual: export MP4, verify video plays with overlay
- [ ] Manual: copy share link, open in new tab, verify auto-replay
- [ ] Manual: verify Firefox shows "unsupported" message for export
- [ ] Manual: verify mobile shows desktop warning