### PR TITLE
feat: add dark/light map style toggle

### DIFF
--- a/src/where_the_plow/static/index.html
+++ b/src/where_the_plow/static/index.html
@@ -92,6 +92,10 @@
                 <div id="search-results" class="search-results-hidden"></div>
                 <div id="search-attribution">Powered by <a href="https://nominatim.openstreetmap.org" target="_blank" rel="noopener">Nominatim</a> &middot; <a href="https://www.openstreetmap.org/copyright" target="_blank" rel="noopener">ODbL</a></div>
             </div>
+            <div id="map-style-toggle" class="toggle-group">
+                <button type="button" id="btn-map-light" title="Light map">Light</button>
+                <button type="button" id="btn-map-dark" title="Dark map">Dark</button>
+            </div>
             <div id="mode-toggle" class="toggle-group">
                 <button id="btn-realtime" class="active">Realtime</button>
                 <button id="btn-coverage">Coverage</button>

--- a/src/where_the_plow/static/style.css
+++ b/src/where_the_plow/static/style.css
@@ -173,6 +173,17 @@ body.controls-left .maplibregl-ctrl-bottom-right .maplibregl-ctrl {
     background: var(--color-hover-bg);
 }
 
+#map-style-toggle {
+    margin: 8px 0 4px;
+    position: relative;
+    z-index: 1;
+}
+
+#map-style-toggle button {
+    padding: 6px 10px;
+    font-size: 12px;
+}
+
 #mode-toggle {
     margin: 8px 0;
 }


### PR DESCRIPTION
Resolves #35 

- Light/Dark buttons switch between OpenFreeMap liberty and dark styles
- Preference stored in localStorage (wtp-map-style)
- Geolocate control re-added after style switch (setStyle removes it)
- Coverage and active vehicle trail restored when switching styles

