### PR TITLE
Reduce idle collector CPU usage

### DIFF
--- a/src/where_the_plow/collector.py
+++ b/src/where_the_plow/collector.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 
 import httpx
@@ -17,7 +18,33 @@ from where_the_plow.db import Database
 logger = logging.getLogger(__name__)
 
 
-def process_poll(db: Database, response, source: str, parser: str) -> int:
+@dataclass
+class SourceState:
+    """Last successfully processed state for one source."""
+
+    position_timestamps: dict[str, datetime] = field(default_factory=dict)
+    vehicle_metadata: dict[str, tuple[str, str]] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class PollResult:
+    vehicles_received: int
+    positions_received: int
+    vehicles_changed: int
+    positions_changed: int
+
+    @property
+    def has_changes(self) -> bool:
+        return self.vehicles_changed > 0 or self.positions_changed > 0
+
+
+def process_poll(
+    db: Database,
+    response,
+    source: str,
+    parser: str,
+    state: SourceState | None = None,
+) -> PollResult:
     """Parse response and store vehicles/positions for a given source."""
     now = datetime.now(timezone.utc)
     if parser == "avl":
@@ -31,9 +58,58 @@ def process_poll(db: Database, response, source: str, parser: str) -> int:
     else:
         raise ValueError(f"Unknown parser: {parser}")
 
-    db.upsert_vehicles(vehicles, now, source=source)
-    inserted = db.insert_positions(positions, now, source=source)
-    return inserted
+    position_timestamps = {
+        position["vehicle_id"]: position["timestamp"] for position in positions
+    }
+    vehicle_metadata = {
+        vehicle["vehicle_id"]: (
+            vehicle["description"],
+            vehicle["vehicle_type"],
+        )
+        for vehicle in vehicles
+    }
+
+    if state is None:
+        changed_position_ids = set(position_timestamps)
+        changed_metadata_ids = set(vehicle_metadata)
+    else:
+        changed_position_ids = {
+            vehicle_id
+            for vehicle_id, timestamp in position_timestamps.items()
+            if state.position_timestamps.get(vehicle_id) != timestamp
+        }
+        changed_metadata_ids = {
+            vehicle_id
+            for vehicle_id, metadata in vehicle_metadata.items()
+            if state.vehicle_metadata.get(vehicle_id) != metadata
+        }
+
+    # Keep last_seen meaningful without rewriting every vehicle on every poll:
+    # update vehicles whose metadata or position changed.
+    changed_vehicle_ids = changed_metadata_ids | changed_position_ids
+    vehicles_to_write = [
+        vehicle for vehicle in vehicles if vehicle["vehicle_id"] in changed_vehicle_ids
+    ]
+    positions_to_write = [
+        position
+        for position in positions
+        if position["vehicle_id"] in changed_position_ids
+    ]
+
+    db.upsert_vehicles(vehicles_to_write, now, source=source)
+    db.insert_positions(positions_to_write, now, source=source)
+
+    # Only advance the in-memory state after both database operations succeed.
+    if state is not None:
+        state.position_timestamps.update(position_timestamps)
+        state.vehicle_metadata.update(vehicle_metadata)
+
+    return PollResult(
+        vehicles_received=len(vehicles),
+        positions_received=len(positions),
+        vehicles_changed=len(vehicles_to_write),
+        positions_changed=len(positions_to_write),
+    )
 
 
 async def poll_source(db: Database, store: dict, source_config):
@@ -43,26 +119,29 @@ async def poll_source(db: Database, store: dict, source_config):
         source_config.display_name,
         source_config.poll_interval,
     )
+    state = SourceState()
     async with httpx.AsyncClient() as client:
         while True:
             try:
                 response = await fetch_source(client, source_config)
-                if isinstance(response, list):
-                    count = len(response)
-                else:
-                    count = len(response.get("features", []))
-                inserted = process_poll(
-                    db, response, source=source_config.name, parser=source_config.parser
+                result = process_poll(
+                    db,
+                    response,
+                    source=source_config.name,
+                    parser=source_config.parser,
+                    state=state,
                 )
                 logger.info(
-                    "[%s] %d vehicles seen, %d positions received",
+                    "[%s] %d vehicles seen, %d/%d positions changed",
                     source_config.name,
-                    count,
-                    inserted,
+                    result.vehicles_received,
+                    result.positions_changed,
+                    result.positions_received,
                 )
-                # Mark this source's snapshot as stale so the next
-                # /vehicles request rebuilds it on demand.
-                store.setdefault("dirty", {})[source_config.name] = True
+                if result.has_changes:
+                    # Mark this source's snapshot as stale so the next
+                    # /vehicles request rebuilds it on demand.
+                    store.setdefault("dirty", {})[source_config.name] = True
             except asyncio.CancelledError:
                 logger.info("Collector for %s shutting down", source_config.name)
                 raise

--- a/src/where_the_plow/db.py
+++ b/src/where_the_plow/db.py
@@ -419,6 +419,11 @@ class Database:
                 result["latest"] = row[1]
         return result
 
+    def ping(self) -> bool:
+        """Run a constant-time query to verify the database connection."""
+        row = self._cursor().execute("SELECT 1").fetchone()
+        return row == (1,)
+
     def insert_viewport(
         self,
         zoom: float,

--- a/src/where_the_plow/main.py
+++ b/src/where_the_plow/main.py
@@ -84,5 +84,5 @@ def root():
 @app.get("/health", tags=["system"])
 def health():
     db: Database = app.state.db
-    stats = db.get_stats()
-    return {"status": "ok", **stats}
+    db.ping()
+    return {"status": "ok"}

--- a/src/where_the_plow/routes.py
+++ b/src/where_the_plow/routes.py
@@ -1,6 +1,7 @@
 # src/where_the_plow/routes.py
 import asyncio
 import logging
+import threading
 import time
 from datetime import datetime, timezone, timedelta
 
@@ -9,6 +10,20 @@ from fastapi import APIRouter, Query, Request, Response
 from fastapi.responses import JSONResponse
 
 from where_the_plow import cache
+from where_the_plow.models import (
+    CoverageFeature,
+    CoverageFeatureCollection,
+    CoverageProperties,
+    Feature,
+    FeatureCollection,
+    FeatureProperties,
+    LineStringGeometry,
+    Pagination,
+    PointGeometry,
+    SignupRequest,
+    StatsResponse,
+    ViewportTrack,
+)
 from where_the_plow.snapshot import build_realtime_snapshot
 
 log = logging.getLogger(__name__)
@@ -66,25 +81,12 @@ def _client_ip(request: Request) -> str:
     )
 
 
-from where_the_plow.models import (
-    CoverageFeature,
-    CoverageFeatureCollection,
-    CoverageProperties,
-    Feature,
-    FeatureCollection,
-    FeatureProperties,
-    LineStringGeometry,
-    Pagination,
-    PointGeometry,
-    SignupRequest,
-    StatsResponse,
-    ViewportTrack,
-)
-
 router = APIRouter()
 
 DEFAULT_LIMIT = 200
 MAX_LIMIT = 2000
+STATS_CACHE_TTL_SECONDS = 60
+_stats_cache_lock = threading.Lock()
 
 
 def _rows_to_feature_collection(rows: list[dict], limit: int) -> FeatureCollection:
@@ -367,7 +369,25 @@ def get_coverage(
 )
 def get_stats(request: Request):
     db = request.app.state.db
-    stats = db.get_stats()
+    now = time.monotonic()
+    cached = getattr(request.app.state, "stats_cache", None)
+
+    if cached is not None and now < cached[0]:
+        stats = cached[1]
+    else:
+        # Avoid a cache stampede when several clients refresh together.
+        with _stats_cache_lock:
+            cached = getattr(request.app.state, "stats_cache", None)
+            now = time.monotonic()
+            if cached is not None and now < cached[0]:
+                stats = cached[1]
+            else:
+                stats = db.get_stats()
+                request.app.state.stats_cache = (
+                    now + STATS_CACHE_TTL_SECONDS,
+                    stats,
+                )
+
     earliest = stats.get("earliest")
     latest = stats.get("latest")
     return StatsResponse(

--- a/src/where_the_plow/static/app.js
+++ b/src/where_the_plow/static/app.js
@@ -830,15 +830,6 @@ function updateVehicleCount(data) {
   const count = data.features ? data.features.length : 0;
   document.getElementById("vehicle-count").textContent =
     count + " vehicle" + (count !== 1 ? "s" : "") + " tracked";
-  fetch("/stats")
-    .then((r) => r.json())
-    .then((stats) => {
-      if (stats.db_size_bytes) {
-        document.getElementById("db-size").textContent =
-          formatBytes(stats.db_size_bytes) + " of data";
-      }
-    })
-    .catch(() => {});
 }
 
 function filterRecentFeatures(data) {
@@ -975,6 +966,10 @@ async function initDatePickerBounds() {
     const stats = await resp.json();
     if (stats.earliest) {
       coverageDateInput.min = stats.earliest.slice(0, 10);
+    }
+    if (stats.db_size_bytes) {
+      document.getElementById("db-size").textContent =
+        formatBytes(stats.db_size_bytes) + " of data";
     }
     coverageDateInput.max = new Date().toISOString().slice(0, 10);
   } catch (e) {

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -7,7 +7,7 @@ import httpx
 import pytest
 
 from where_the_plow.client import fetch_source
-from where_the_plow.collector import poll_source, process_poll
+from where_the_plow.collector import SourceState, poll_source, process_poll
 from where_the_plow.db import Database
 from where_the_plow.source_config import SourceConfig
 
@@ -75,8 +75,8 @@ def make_db():
 
 def test_process_poll_avl():
     db, path = make_db()
-    inserted = process_poll(db, SAMPLE_AVL_RESPONSE, source="st_johns", parser="avl")
-    assert inserted == 1
+    result = process_poll(db, SAMPLE_AVL_RESPONSE, source="st_johns", parser="avl")
+    assert result.positions_changed == 1
     row = db.conn.execute(
         "SELECT source FROM positions WHERE vehicle_id='6819'"
     ).fetchone()
@@ -87,10 +87,10 @@ def test_process_poll_avl():
 
 def test_process_poll_aatracking():
     db, path = make_db()
-    inserted = process_poll(
+    result = process_poll(
         db, SAMPLE_AATRACKING_RESPONSE, source="mt_pearl", parser="aatracking"
     )
-    assert inserted == 1
+    assert result.positions_changed == 1
     row = db.conn.execute(
         "SELECT source FROM positions WHERE vehicle_id='17186'"
     ).fetchone()
@@ -101,10 +101,10 @@ def test_process_poll_aatracking():
 
 def test_process_poll_hitechmaps():
     db, path = make_db()
-    inserted = process_poll(
+    result = process_poll(
         db, SAMPLE_HITECHMAPS_RESPONSE, source="paradise", parser="hitechmaps"
     )
-    assert inserted == 1
+    assert result.positions_changed == 1
     row = db.conn.execute(
         "SELECT source FROM positions WHERE vehicle_id='b3C'"
     ).fetchone()
@@ -115,8 +115,8 @@ def test_process_poll_hitechmaps():
 
 def test_process_poll_geotab():
     db, path = make_db()
-    inserted = process_poll(db, SAMPLE_GEOTAB_RESPONSE, source="cbs", parser="geotab")
-    assert inserted == 2
+    result = process_poll(db, SAMPLE_GEOTAB_RESPONSE, source="cbs", parser="geotab")
+    assert result.positions_changed == 2
     row = db.conn.execute(
         "SELECT source FROM positions WHERE vehicle_id='b21'"
     ).fetchone()
@@ -127,12 +127,48 @@ def test_process_poll_geotab():
 
 def test_process_poll_deduplicates():
     db, path = make_db()
-    received1 = process_poll(db, SAMPLE_AVL_RESPONSE, source="st_johns", parser="avl")
-    received2 = process_poll(db, SAMPLE_AVL_RESPONSE, source="st_johns", parser="avl")
-    assert received1 == 1
-    assert received2 == 1  # returns received count, duplicates ignored at DB level
+    state = SourceState()
+    result1 = process_poll(
+        db, SAMPLE_AVL_RESPONSE, source="st_johns", parser="avl", state=state
+    )
+    result2 = process_poll(
+        db, SAMPLE_AVL_RESPONSE, source="st_johns", parser="avl", state=state
+    )
+    assert result1.positions_received == 1
+    assert result1.positions_changed == 1
+    assert result2.positions_received == 1
+    assert result2.positions_changed == 0
+    assert result2.vehicles_changed == 0
+    assert result2.has_changes is False
     total = db.conn.execute("SELECT count(*) FROM positions").fetchone()[0]
     assert total == 1
+    db.close()
+    os.unlink(path)
+
+
+def test_process_poll_detects_metadata_change_without_position_change():
+    db, path = make_db()
+    state = SourceState()
+    process_poll(db, SAMPLE_AVL_RESPONSE, source="st_johns", parser="avl", state=state)
+    changed_response = {
+        "features": [
+            {
+                **SAMPLE_AVL_RESPONSE["features"][0],
+                "attributes": {
+                    **SAMPLE_AVL_RESPONSE["features"][0]["attributes"],
+                    "VehicleType": "LOADER",
+                },
+            }
+        ]
+    }
+
+    result = process_poll(
+        db, changed_response, source="st_johns", parser="avl", state=state
+    )
+
+    assert result.positions_changed == 0
+    assert result.vehicles_changed == 1
+    assert result.has_changes is True
     db.close()
     os.unlink(path)
 
@@ -179,7 +215,7 @@ def _make_aatracking_response(vehicle_id=17186, heading=90):
     ]
 
 
-async def _run_poll_cycles(db, store, config, side_effects):
+async def _run_poll_cycles(db, store, config, side_effects, after_cycle=None):
     """Run poll_source with mocked fetch_source, cancelling after N cycles.
 
     side_effects: list of (return_value_or_exception) for each poll cycle.
@@ -201,6 +237,8 @@ async def _run_poll_cycles(db, store, config, side_effects):
     original_sleep = asyncio.sleep
 
     async def fake_sleep(seconds):
+        if after_cycle is not None:
+            after_cycle(call_count, store)
         # After each cycle completes (sleep is called at end of loop body),
         # check if we've done enough cycles
         if call_count >= target_cycles:
@@ -313,6 +351,28 @@ async def test_poll_source_updates_store_on_success():
     assert "dirty" in store
     assert store["dirty"].get("test_source") is True
 
+    db.close()
+    os.unlink(path)
+
+
+async def test_poll_source_does_not_redirty_unchanged_source():
+    db, path = make_db()
+    store = {}
+    config = _test_source_config()
+
+    def clear_dirty_after_first_cycle(cycle, current_store):
+        if cycle == 1:
+            current_store["dirty"]["test_source"] = False
+
+    await _run_poll_cycles(
+        db,
+        store,
+        config,
+        [_make_aatracking_response(), _make_aatracking_response()],
+        after_cycle=clear_dirty_after_first_cycle,
+    )
+
+    assert store["dirty"]["test_source"] is False
     db.close()
     os.unlink(path)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -41,9 +41,11 @@ def test_client():
 
 
 def test_health(test_client):
-    resp = test_client.get("/health")
+    db = test_client.app.state.db
+
+    with patch.object(db, "ping", wraps=db.ping) as ping:
+        resp = test_client.get("/health")
+
     assert resp.status_code == 200
-    data = resp.json()
-    assert data["status"] == "ok"
-    assert "total_positions" in data
-    assert "total_vehicles" in data
+    assert resp.json() == {"status": "ok"}
+    assert ping.call_count == 1

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -182,6 +182,19 @@ def test_get_stats(test_client):
     assert data["db_size_bytes"] > 0
 
 
+def test_get_stats_is_cached(test_client):
+    db = test_client.app.state.db
+
+    with patch.object(db, "get_stats", wraps=db.get_stats) as get_stats:
+        first = test_client.get("/stats")
+        second = test_client.get("/stats")
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert first.json() == second.json()
+    assert get_stats.call_count == 1
+
+
 def test_track_viewport(test_client):
     resp = test_client.post(
         "/track",


### PR DESCRIPTION
## Summary

- keep per-source poll state and skip unchanged vehicle/position writes
- mark snapshots dirty only when a feed actually changes
- replace the expensive health aggregate with a lightweight DB ping
- cache stats for 60 seconds and stop polling them every six seconds from each browser

## Evidence

On production, St. John’s database processing took 3.25–10.58 seconds per six-second poll (4.13-second median) while only 3–4 of 101 positions typically changed. A 13.6-million-row synthetic database using the real collector path measured:

- first reconciliation: 134.8 ms
- unchanged poll: 0.2 ms
- three changed positions: 4.8 ms

The optimized local service also confirmed change-aware behavior against live feeds: 6/101 and 11/101 St. John’s writes on consecutive polls, and 0/20 for an unchanged Paradise poll.

## Validation

- `uv run pytest` — 105 passed, 1 skipped
- changed-file `ruff format --check` and `ruff check`
- `node --check src/where_the_plow/static/app.js`
- `git diff --check`

A local Docker build could not be completed because the Docker runtime stalled resolving remote base-image metadata; it did not reach the project build steps.